### PR TITLE
Improve layout consistency and lint types

### DIFF
--- a/src/app/styles/tokens.css
+++ b/src/app/styles/tokens.css
@@ -88,6 +88,23 @@ a:hover { color: var(--brand-700); }
 }
 .input:focus { outline: 2px solid var(--brand-500); outline-offset:2px; }
 
+/* Layout helpers */
+.container {
+  width: 100%;
+  max-width: 1200px;
+  margin-left: auto;
+  margin-right: auto;
+  padding-left: 16px;
+  padding-right: 16px;
+}
+
+@media (min-width: 640px) {
+  .container {
+    padding-left: 24px;
+    padding-right: 24px;
+  }
+}
+
 .card {
   background:var(--bg-elev); border:1px solid var(--border);
   border-radius:var(--radius-lg); box-shadow:var(--shadow-1); padding:16px;

--- a/src/components/FinalCTA.tsx
+++ b/src/components/FinalCTA.tsx
@@ -22,9 +22,9 @@ export function FinalCTA() {
       setState("ok");
       setMsg("Готово! Мы сообщим о релизе и раннем доступе.");
       setEmail("");
-    } catch (err: any) {
+    } catch (err: unknown) {
       setState("err");
-      setMsg(err.message || "Что-то пошло не так");
+      setMsg(err instanceof Error ? err.message : "Что-то пошло не так");
     }
   };
 


### PR DESCRIPTION
## Summary
- add responsive container helper for consistent page centering
- fix FinalCTA error handling to avoid `any`

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68ab1419210c832c982121efb13178e4