### PR TITLE
feat: add dialogue-style testimonials section

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@ import { Hero } from "@/components/Hero";
 import { ScrollyCopy } from "@/components/ScrollyCopy";
 import { Benefits } from "@/components/Benefits";
 import { TryOn } from "@/components/TryOn";
+import { Testimonials } from "@/components/Testimonials";
 import { FinalCTA } from "@/components/FinalCTA";
 import { Footer } from "@/components/Footer";
 
@@ -12,6 +13,7 @@ export default function Page() {
       <ScrollyCopy text="Neo - это стилист на базе искусственного ителлекта, который помогает выбирать одежду проще, увереннее и быстрее на основе ваших персональных параметров и предпочтений." />
       <Benefits />
       <TryOn />
+      <Testimonials />
       <FinalCTA />
       <Footer />
     </>

--- a/src/components/Testimonials.tsx
+++ b/src/components/Testimonials.tsx
@@ -1,0 +1,77 @@
+import Image from "next/image";
+
+type Testimonial = {
+  name: string;
+  role: string;
+  text: string;
+  avatar: string;
+};
+
+const testimonials: Testimonial[] = [
+  {
+    name: "Сара Левин",
+    role: "продакт-менеджер из Парижа",
+    text: "Сервис развивается с каждым годом. Люблю, что можно получить совет по стилю сразу, как только нужна помощь.",
+    avatar: "/person.jpg",
+  },
+  {
+    name: "Самуэль Уилсон",
+    role: "креативный директор в DCD",
+    text: "Главное в Stylist AI — его вдохновение. Это как иметь личного стилиста в кармане.",
+    avatar: "/person.jpg",
+  },
+  {
+    name: "Алекс Леркинс",
+    role: "основатель Pet Studio",
+    text: "Мы строим сообщество вокруг моды, и сервис помогает оставаться на связи и делиться образами.",
+    avatar: "/person.jpg",
+  },
+];
+
+export function Testimonials() {
+  return (
+    <section className="py-24">
+      <div className="container">
+        <h2 className="font-serif text-4xl text-center">Нас любят клиенты</h2>
+        <div className="mt-12 space-y-8" aria-label="Отзывы клиентов">
+          {testimonials.map((t, i) => {
+            const reversed = i % 2 === 1;
+            return (
+              <div
+                key={t.name}
+                className={`flex items-start gap-4 ${reversed ? "flex-row-reverse text-right" : ""}`}
+              >
+                <Image
+                  src={t.avatar}
+                  alt={t.name}
+                  width={48}
+                  height={48}
+                  className="rounded-full object-cover"
+                />
+                <div
+                  className={`relative bg-gray-100 p-4 rounded-2xl max-w-md ${
+                    reversed ? "rounded-tr-none" : "rounded-tl-none"
+                  }`}
+                >
+                  <blockquote className="text-black/70">{t.text}</blockquote>
+                  <div className="mt-4">
+                    <div className="font-semibold">{t.name}</div>
+                    <div className="text-sm text-black/70">{t.role}</div>
+                  </div>
+                  <span
+                    className={`absolute top-6 ${
+                      reversed ? "right-0 translate-x-full" : "left-0 -translate-x-full"
+                    } border-y-8 border-y-transparent ${
+                      reversed ? "border-l-8 border-l-gray-100" : "border-r-8 border-r-gray-100"
+                    }`}
+                  />
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </section>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add testimonials section component with sample client quotes
- display testimonials on the landing page in a dialogue-style layout

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab55ca06b4832cb6f69e7d0e977a22