### PR TITLE
feat: add smooth transitions

### DIFF
--- a/src/app/styles/tokens.css
+++ b/src/app/styles/tokens.css
@@ -70,7 +70,11 @@ body {
 }
 
 /* Elements */
-a { color: var(--brand-600); text-decoration: none; }
+a {
+  color: var(--brand-600);
+  text-decoration: none;
+  transition: color var(--timing-base) var(--ease-smooth);
+}
 a:hover { color: var(--brand-700); }
 .button {
   display:inline-flex; align-items:center; justify-content:center; gap:.5rem;
@@ -85,6 +89,8 @@ a:hover { color: var(--brand-700); }
 .input {
   height:48px; padding:0 12px; border-radius:var(--radius-md);
   border:1px solid var(--border); background:var(--bg-elev); color:var(--fg-primary);
+  transition: border-color var(--timing-base) var(--ease-smooth),
+              outline-color var(--timing-base) var(--ease-smooth);
 }
 .input:focus { outline: 2px solid var(--brand-500); outline-offset:2px; }
 
@@ -108,6 +114,12 @@ a:hover { color: var(--brand-700); }
 .card {
   background:var(--bg-elev); border:1px solid var(--border);
   border-radius:var(--radius-lg); box-shadow:var(--shadow-1); padding:16px;
+  transition: box-shadow var(--timing-base) var(--ease-smooth),
+              transform var(--timing-base) var(--ease-smooth);
+}
+.card:hover {
+  box-shadow: var(--shadow-2);
+  transform: translateY(-2px);
 }
 
 .badge {

--- a/src/components/FAQ.tsx
+++ b/src/components/FAQ.tsx
@@ -32,7 +32,7 @@ export const FAQ: FC = () => {
               <summary className="flex w-full cursor-pointer items-center justify-between list-none font-medium">
                 <span>{item.q}</span>
                 <svg
-                  className="ml-4 h-5 w-5 shrink-0 transition-transform duration-300 group-open:rotate-180"
+                  className="ml-4 h-5 w-5 shrink-0 transition-transform duration-[var(--timing-base)] group-open:rotate-180"
                   viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"
                 >
                   <path strokeLinecap="round" strokeLinejoin="round" d="M6 9l6 6 6-6" />
@@ -42,16 +42,16 @@ export const FAQ: FC = () => {
               {/* Контейнер-гармошка: плавно меняем 'высоту' через grid-rows */}
               <div
                 className="mt-2 grid grid-rows-[0fr] overflow-hidden
-                           transition-[grid-template-rows] duration-300
-                           ease-[cubic-bezier(.2,.8,.2,1)]
+                           transition-[grid-template-rows] duration-[var(--timing-base)]
+                           ease-[var(--ease-smooth)]
                            group-open:grid-rows-[1fr] motion-reduce:transition-none"
               >
                 {/* Внутренний блок, чтобы сработал 0fr → 1fr */}
                 <div className="min-h-0 overflow-hidden">
                   <p
                     className="mb-0 text-black/70 opacity-0 translate-y-1
-                               transition-[opacity,transform] duration-500
-                               ease-[cubic-bezier(.2,.8,.2,1)]
+                               transition-[opacity,transform] duration-[var(--timing-slow)]
+                               ease-[var(--ease-smooth)]
                                group-open:opacity-100 group-open:translate-y-0
                                motion-reduce:transition-none"
                   >

--- a/src/components/FinalCTA.tsx
+++ b/src/components/FinalCTA.tsx
@@ -50,7 +50,7 @@ export function FinalCTA() {
               onChange={(e) => setEmail(e.target.value)}
               aria-label="Email для подписки"
             />
-            <button disabled={state === "loading"} className="btn btn-primary" type="submit">
+            <button disabled={state === "loading"} className="button primary" type="submit">
               {state === "loading" ? "Отправка..." : "Подписаться"}
             </button>
           </form>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -27,7 +27,12 @@ export function Header() {
           {/* Desktop navigation */}
           <nav className="hidden md:flex items-center gap-8">
             {navItems.map((item) => (
-              <Link key={item.href} href={item.href} className="text-sm text-black/70 hover:text-black" onClick={() => setMenuOpen(false)}>
+              <Link
+                key={item.href}
+                href={item.href}
+                className="text-sm text-black/70 hover:text-black transition-colors"
+                onClick={() => setMenuOpen(false)}
+              >
                 {item.label}
               </Link>
             ))}
@@ -60,7 +65,7 @@ export function Header() {
                 <Link
                   key={item.href}
                   href={item.href}
-                  className="text-sm text-black/70"
+                  className="text-sm text-black/70 hover:text-black transition-colors"
                   onClick={() => setMenuOpen(false)}
                 >
                   {item.label}


### PR DESCRIPTION
## Summary
- smooth link and card hover transitions via shared tokens
- use design variables in FAQ accordion animation
- unify CTA button styling and add nav link transitions

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab95e77048832c8bf3908a2bce2eee