### PR TITLE
Replace PostHog with Yandex Metrica

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AI Stylist Landing
 
-Landing page built with Next.js. It collects leads and quiz answers, writes server events to Supabase and PostHog and sends Telegram notifications.
+Landing page built with Next.js. It collects leads and quiz answers, writes server events to Supabase and Yandex Metrica and sends Telegram notifications.
 
 ## Setup
 
@@ -8,7 +8,7 @@ Landing page built with Next.js. It collects leads and quiz answers, writes serv
    ```bash
    pnpm install
    ```
-2. Copy `.env.example` to `.env` and fill in values for Supabase, PostHog and Telegram.
+2. Copy `.env.example` to `.env` and fill in values for Supabase, Yandex Metrica and Telegram.
 3. Apply database schema to your Supabase project:
    ```bash
    pnpm supabase < scripts/supabase.sql
@@ -39,8 +39,8 @@ See `.env.example` for the full list:
 - `SUPABASE_SERVICE_ROLE_KEY`
 - `TELEGRAM_BOT_TOKEN`
 - `TELEGRAM_CHAT_ID`
-- `POSTHOG_API_KEY` / `POSTHOG_API_HOST`
-- `NEXT_PUBLIC_POSTHOG_KEY` / `NEXT_PUBLIC_POSTHOG_HOST`
+- `YANDEX_METRICA_ID`
+- `NEXT_PUBLIC_YANDEX_METRICA_ID`
 
 ## Tests
 

--- a/package.json
+++ b/package.json
@@ -10,12 +10,11 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@supabase/supabase-js": "^2.45.3",
     "clsx": "^2.1.1",
     "next": "15.5.0",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "@supabase/supabase-js": "^2.45.3",
-    "posthog-js": "^1.200.4",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
       next:
         specifier: 15.5.0
         version: 15.5.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      posthog-js:
-        specifier: ^1.200.4
-        version: 1.260.2
       react:
         specifier: 19.1.0
         version: 19.1.0
@@ -1073,9 +1070,6 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
-  core-js@3.45.1:
-    resolution: {integrity: sha512-L4NPsJlCfZsPeXukyzHFlg/i7IIVwHSItR0wg0FLNqYClJ4MQYTYLbC7EkjKYRLZF2iof2MUgN0EGy7MdQFChg==}
-
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -1344,9 +1338,6 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
-
-  fflate@0.4.8:
-    resolution: {integrity: sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==}
 
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
@@ -1878,20 +1869,6 @@ packages:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
 
-  posthog-js@1.260.2:
-    resolution: {integrity: sha512-2Q+QUz9j9+uG16wp0WcOEbezVsLZCobZyTX8NvWPMGKyPaf2lOsjbPjznsq5JiIt324B6NAqzpWYZTzvhn9k9Q==}
-    peerDependencies:
-      '@rrweb/types': 2.0.0-alpha.17
-      rrweb-snapshot: 2.0.0-alpha.17
-    peerDependenciesMeta:
-      '@rrweb/types':
-        optional: true
-      rrweb-snapshot:
-        optional: true
-
-  preact@10.27.1:
-    resolution: {integrity: sha512-V79raXEWch/rbqoNc7nT9E4ep7lu+mI3+sBmfRD4i1M73R3WLYcCtdI0ibxGVf4eQL8ZIz2nFacqEC+rmnOORQ==}
-
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -2243,9 +2220,6 @@ packages:
         optional: true
       jsdom:
         optional: true
-
-  web-vitals@4.2.4:
-    resolution: {integrity: sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
@@ -3196,8 +3170,6 @@ snapshots:
 
   concat-map@0.0.1: {}
 
-  core-js@3.45.1: {}
-
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -3632,8 +3604,6 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
-
-  fflate@0.4.8: {}
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -4148,15 +4118,6 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  posthog-js@1.260.2:
-    dependencies:
-      core-js: 3.45.1
-      fflate: 0.4.8
-      preact: 10.27.1
-      web-vitals: 4.2.4
-
-  preact@10.27.1: {}
-
   prelude-ls@1.2.1: {}
 
   prop-types@15.8.1:
@@ -4627,8 +4588,6 @@ snapshots:
       - sugarss
       - supports-color
       - terser
-
-  web-vitals@4.2.4: {}
 
   webidl-conversions@3.0.1: {}
 

--- a/src/lib/analytics-server.ts
+++ b/src/lib/analytics-server.ts
@@ -1,15 +1,10 @@
 export async function captureEvent(name: string, properties?: Record<string, unknown>) {
-  const key = process.env.POSTHOG_API_KEY || process.env.NEXT_PUBLIC_POSTHOG_KEY;
-  if (!key) return;
-  const host =
-    process.env.POSTHOG_API_HOST || process.env.NEXT_PUBLIC_POSTHOG_HOST || "https://eu.posthog.com";
-  await fetch(`${host}/capture/`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      api_key: key,
-      event: name,
-      properties,
-    }),
-  }).catch(() => {});
+  const id = process.env.YANDEX_METRICA_ID || process.env.NEXT_PUBLIC_YANDEX_METRICA_ID;
+  if (!id) return;
+  const url = new URL(`https://mc.yandex.ru/watch/${id}`);
+  url.searchParams.set("event", name);
+  if (properties) {
+    url.searchParams.set("params", JSON.stringify(properties));
+  }
+  await fetch(url.toString()).catch(() => {});
 }

--- a/src/lib/analytics.tsx
+++ b/src/lib/analytics.tsx
@@ -1,15 +1,36 @@
 "use client";
-import { useEffect } from "react";
-import posthog from "posthog-js";
 
-export function AnalyticsProvider({ children }: { children: React.ReactNode }) {
-  useEffect(() => {
-    const key = process.env.NEXT_PUBLIC_POSTHOG_KEY;
-    if (!key) return;
-    posthog.init(key, {
-      api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST || "https://eu.posthog.com",
-      capture_pageview: true,
-    });
-  }, []);
-  return <>{children}</>;
+import Script from "next/script";
+import type { ReactNode } from "react";
+
+export function AnalyticsProvider({ children }: { children: ReactNode }) {
+  const id = process.env.NEXT_PUBLIC_YANDEX_METRICA_ID;
+  return (
+    <>
+      {id && (
+        <>
+          <Script id="yandex-metrica" strategy="afterInteractive">
+            {`
+              (function(m,e,t,r,i,k,a){m[i]=m[i]||function(){(m[i].a=m[i].a||[]).push(arguments)};
+              m[i].l=1*new Date();
+              k=e.createElement(t),a=e.getElementsByTagName(t)[0],k.async=1,k.src=r,a.parentNode.insertBefore(k,a)})
+              (window, document, "script", "https://mc.yandex.ru/metrika/tag.js", "ym");
+              ym(${id}, "init", { clickmap:true, trackLinks:true, accurateTrackBounce:true });
+            `}
+          </Script>
+          <noscript>
+            <div>
+              <img
+                src={`https://mc.yandex.ru/watch/${id}`}
+                style={{ position: "absolute", left: "-9999px" }}
+                alt=""
+              />
+            </div>
+          </noscript>
+        </>
+      )}
+      {children}
+    </>
+  );
 }
+


### PR DESCRIPTION
## Summary
- replace PostHog analytics with a Yandex Metrica provider and noscript fallback
- forward server-side events to Yandex Metrica
- remove posthog-js dependency and document new Yandex env vars

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68abe4869ba0832cbccabcbd76c11d14