### PR TITLE
feat: add email opt-in before quiz

### DIFF
--- a/src/components/FinalCTA.tsx
+++ b/src/components/FinalCTA.tsx
@@ -1,9 +1,14 @@
 "use client";
 
+import { useState } from "react";
 import { useQuiz } from "./QuizProvider";
 
 export function FinalCTA() {
   const { open } = useQuiz();
+  const [email, setEmail] = useState("");
+
+  const handleClick = () => open(email);
+
   return (
     <section id="cta" className="py-24">
       <div className="container text-center">
@@ -13,9 +18,22 @@ export function FinalCTA() {
           <p className="mt-3 text-lg text-black/70">
             Ответьте на 6 вопросов и получите 3 образа.
           </p>
-          <button className="button primary mt-6" onClick={open}>
-            Попробовать бесплатно
-          </button>
+          <div className="mt-6 flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
+            <input
+              type="email"
+              placeholder="Ваш email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              className="input w-full max-w-xs"
+            />
+            <button
+              className="button primary w-full max-w-xs"
+              onClick={handleClick}
+              disabled={!email}
+            >
+              Попробовать бесплатно
+            </button>
+          </div>
         </div>
       </div>
     </section>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,11 +3,9 @@
 import { useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
-import { useQuiz } from "./QuizProvider";
 
 export function Header() {
   const [menuOpen, setMenuOpen] = useState(false);
-  const { open } = useQuiz();
 
   const navItems = [
     { href: "#how", label: "Как это работает" },
@@ -41,15 +39,13 @@ export function Header() {
           </nav>
 
           <div className="flex items-center gap-4">
-            <button
-              onClick={() => {
-                setMenuOpen(false);
-                open();
-              }}
+            <Link
+              href="#cta"
+              onClick={() => setMenuOpen(false)}
               className="button primary hidden md:inline-flex"
             >
               Попробовать бесплатно
-            </button>
+            </Link>
             {/* Mobile hamburger */}
             <button
               className="md:hidden p-2"
@@ -79,15 +75,13 @@ export function Header() {
                   {item.label}
                 </Link>
               ))}
-              <button
+              <Link
+                href="#cta"
                 className="button primary"
-                onClick={() => {
-                  setMenuOpen(false);
-                  open();
-                }}
+                onClick={() => setMenuOpen(false)}
               >
                 Попробовать бесплатно
-              </button>
+              </Link>
             </div>
           </div>
         )}

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useQuiz } from "./QuizProvider";
 
 export function Hero() {
   const videoRef = useRef<HTMLVideoElement>(null);
   const { open } = useQuiz();
+  const [email, setEmail] = useState("");
 
   useEffect(() => {
     // Автовоспроизведение тихого видео на iOS/desktop
@@ -39,12 +40,22 @@ export function Hero() {
         <p className="mt-4 max-w-xl text-lg text-black/70">
           Загрузите фото и получите 3 образа за 30 секунд. С точными размерами и ссылками на покупку.
         </p>
-        <button
-          className="button primary mt-6"
-          onClick={open}
-        >
-          Попробовать бесплатно
-        </button>
+        <div className="mt-6 flex flex-col gap-3 sm:flex-row">
+          <input
+            type="email"
+            placeholder="Ваш email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="input w-full sm:w-auto"
+          />
+          <button
+            className="button primary"
+            onClick={() => open(email)}
+            disabled={!email}
+          >
+            Попробовать бесплатно
+          </button>
+        </div>
       </div>
     </section>
   );

--- a/src/components/Quiz.tsx
+++ b/src/components/Quiz.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 
 interface QuizProps {
   onClose: () => void;
+  initialEmail?: string;
 }
 
 // initial data structure
@@ -34,7 +35,7 @@ interface QuizData {
   consent_marketing: boolean;
 }
 
-export function Quiz({ onClose }: QuizProps) {
+export function Quiz({ onClose, initialEmail }: QuizProps) {
   const totalSteps = 6;
   const [step, setStep] = useState(0);
   const [tab, setTab] = useState<"photo" | "params">("photo");
@@ -49,7 +50,7 @@ export function Quiz({ onClose }: QuizProps) {
     marketplaces: [],
     avoid_items: [],
     contact_type: "email",
-    contact_value: "",
+    contact_value: initialEmail || "",
     consent_personal: false,
     consent_marketing: false,
   });

--- a/src/components/QuizProvider.tsx
+++ b/src/components/QuizProvider.tsx
@@ -4,13 +4,14 @@ import { createContext, useContext, useEffect, useState, ReactNode } from "react
 import { Quiz } from "./Quiz";
 
 interface QuizContextValue {
-  open: () => void;
+  open: (email?: string) => void;
 }
 
 const QuizContext = createContext<QuizContextValue | undefined>(undefined);
 
 export function QuizProvider({ children }: { children: ReactNode }) {
   const [isOpen, setIsOpen] = useState(false);
+  const [initialEmail, setInitialEmail] = useState<string | undefined>();
 
   useEffect(() => {
     if (isOpen && typeof window !== "undefined") {
@@ -20,10 +21,20 @@ export function QuizProvider({ children }: { children: ReactNode }) {
     }
   }, [isOpen]);
 
+  const open = (email?: string) => {
+    setInitialEmail(email);
+    setIsOpen(true);
+  };
+
   return (
-    <QuizContext.Provider value={{ open: () => setIsOpen(true) }}>
+    <QuizContext.Provider value={{ open }}>
       {children}
-      {isOpen && <Quiz onClose={() => setIsOpen(false)} />}
+      {isOpen && (
+        <Quiz
+          onClose={() => setIsOpen(false)}
+          initialEmail={initialEmail}
+        />
+      )}
     </QuizContext.Provider>
   );
 }


### PR DESCRIPTION
## Summary
- add email field to hero and final CTA to collect address before opening quiz
- pass email through provider to prefill quiz contact info
- make header and other CTAs link to final call-to-action section

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68abbb151f14832cabd6792664f1f851