### PR TITLE
feat: add anchor ids for landing sections

### DIFF
--- a/src/components/Benefits.tsx
+++ b/src/components/Benefits.tsx
@@ -20,7 +20,7 @@ const benefits: Benefit[] = [
 
 export function Benefits() {
   return (
-    <section className="py-16">
+    <section id="benefits" className="py-16">
       <div className="container grid gap-6 md:grid-cols-3" aria-label="Что вы получите">
         {benefits.map((b) => (
           <div key={b.title} className="card">

--- a/src/components/FAQ.tsx
+++ b/src/components/FAQ.tsx
@@ -17,7 +17,7 @@ const items: FAQItem[] = [
 
 export const FAQ: FC = () => {
   return (
-    <section className="py-16">
+    <section id="faq" className="py-16">
       <div className="container max-w-3xl">
         <h2 className="text-center font-serif text-4xl">Есть вопросы? Мы рады ответить</h2>
 

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 
 export function Footer() {
   return (
-    <footer className="bg-gray-50 mt-16">
+    <footer id="contacts" className="bg-gray-50 mt-16">
       <div className="container py-10 space-y-10">
         {/* Top row with logo and CTA */}
         <div className="flex items-center">

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -10,9 +10,9 @@ export function Header() {
   const { open } = useQuiz();
 
   const navItems = [
+    { href: "#benefits", label: "Преимущества" },
     { href: "#how", label: "Как это работает" },
     { href: "#examples", label: "Примеры образов" },
-    { href: "#pricing", label: "Тарифы" },
     { href: "#faq", label: "FAQ" },
     { href: "#contacts", label: "Контакты" },
   ];

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -9,7 +9,7 @@ export function Hero() {
   const { open } = useQuiz();
 
   return (
-    <section className="relative h-[100svh] min-h-[560px] w-full overflow-hidden">
+    <section id="hero" className="relative h-[100svh] min-h-[560px] w-full overflow-hidden">
         <Image
             src="/hero.jpg"            // положи файл в /public/hero.jpg (или .webp)
             alt=""

--- a/src/components/HowItWorks.tsx
+++ b/src/components/HowItWorks.tsx
@@ -12,7 +12,7 @@ export function HowItWorks() {
   ];
 
   return (
-    <section className="py-24" aria-labelledby="hiw-title">
+    <section id="how" className="py-24" aria-labelledby="hiw-title">
       <div className="container">
         <h2 id="hiw-title" className="text-center font-serif text-4xl">
           Как это работает — 3 шага и готовые образы

--- a/src/components/ScrollyCopy.tsx
+++ b/src/components/ScrollyCopy.tsx
@@ -44,7 +44,7 @@ export function ScrollyCopy({
   const coloredCount = Math.round(progress * total);
 
   return (
-    <section className="py-28">
+    <section id="about" className="py-28">
       <div className="container">
         <h2
           ref={ref}

--- a/src/components/Testimonials.tsx
+++ b/src/components/Testimonials.tsx
@@ -30,7 +30,7 @@ const testimonials: Testimonial[] = [
 
 export function Testimonials() {
   return (
-    <section className="py-24">
+    <section id="testimonials" className="py-24">
       <div className="container">
         <h2 className="font-serif text-4xl text-center">Нас любят клиенты</h2>
         <div

--- a/src/components/TryOn.tsx
+++ b/src/components/TryOn.tsx
@@ -36,7 +36,7 @@ export function TryOn() {
   const bottom = bottoms[tick % bottoms.length];
 
   return (
-    <section id="how" className="py-28">
+    <section id="examples" className="py-28">
       {/* шире контейнер, чтобы всё стало крупнее */}
       <div className="mx-auto max-w-7xl rounded-[32px] bg-white p-6 md:p-12 ring-1 ring-black/5 shadow-[0_50px_80px_rgba(24,20,18,.06)] grid grid-cols-1 items-center gap-12 md:grid-cols-[1.1fr_.9fr]">
 


### PR DESCRIPTION
## Summary
- assign hash anchors to landing sections and footer
- link header navigation to new anchors

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68abe6d49a04832cb1f7b69e1a784e93