### PR TITLE
Show three badges in hero section

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,11 +1,10 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useState } from "react";
 import { useQuiz } from "./QuizProvider";
 import Image from "next/image";
 
 export function Hero() {
-  const videoRef = useRef<HTMLVideoElement>(null);
   const { open } = useQuiz();
   const [email, setEmail] = useState("");
 
@@ -20,10 +19,17 @@ export function Hero() {
         />
       <div className="absolute inset-0 bg-white/40 backdrop-blur-[1px]" />
       <div className="relative z-10 container h-full flex flex-col items-start justify-center">
-        <span className="inline-flex items-center gap-2 rounded-full bg-white/70 px-3 py-1 text-sm">
-          <span className="h-2 w-2 rounded-full bg-[var(--brand-600)]" />
-          ИИ-стилист для реальных людей
-        </span>
+        <div className="flex flex-wrap gap-2">
+          {["ИИ-стилист", "Для реальных людей", "Бесплатно"].map((text) => (
+            <span
+              key={text}
+              className="inline-flex items-center gap-2 rounded-full bg-white/70 px-3 py-1 text-sm"
+            >
+              <span className="h-2 w-2 rounded-full bg-[var(--brand-600)]" />
+              {text}
+            </span>
+          ))}
+        </div>
         <h1 className="mt-4 max-w-2xl font-serif text-5xl leading-[1.1]">
           Поможем одеться быстро и стильно
         </h1>


### PR DESCRIPTION
## Summary
- add three informative badges above hero heading
- simplify Hero component by removing unused imports

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68abea2f39e8832ca4affbd3ee610585