### PR TITLE
Add NEO logo and overlay header on hero

### DIFF
--- a/public/neo-logo.svg
+++ b/public/neo-logo.svg
@@ -1,0 +1,9 @@
+<svg width="120" height="40" viewBox="0 0 120 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <!-- N -->
+  <path d="M0 0V40H8V15L32 40H40V0H32V25L8 0H0Z" fill="#111111"/>
+  <!-- E as bars -->
+  <rect x="50" y="10" width="24" height="6" fill="#D9C5B5"/>
+  <rect x="50" y="24" width="24" height="6" fill="#D9C5B5"/>
+  <!-- O -->
+  <circle cx="96" cy="20" r="16" stroke="#111111" stroke-width="8" fill="none"/>
+</svg>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -17,10 +17,17 @@ export function Header() {
   return (
     <>
       {/* Main header */}
-      <header className="bg-white/100 backdrop-blur sticky top-0 z-50 w-full">
+      <header className="fixed top-0 left-0 z-50 w-full bg-white/80 backdrop-blur">
         <div className="container flex items-center justify-between py-4">
-          <Link href="/" className="flex items-center" aria-label="Stylist AI">
-            <Image src="/logo.svg" alt="Stylist AI" width={120} height={24} />
+          <Link href="/" className="flex items-center" aria-label="NEO">
+            <Image
+              src="/neo-logo.svg"
+              alt="NEO"
+              width={120}
+              height={40}
+              className="h-10 w-auto md:h-12"
+              priority
+            />
           </Link>
 
           {/* Desktop navigation */}


### PR DESCRIPTION
## Summary
- replace header logo with new NEO branding
- position header fixed with translucent background so it overlays the hero section

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68abf53d9800832c8d77cd310766d766