### PR TITLE
Add thank-you page and streamline quiz contact step

### DIFF
--- a/src/app/thanks/page.tsx
+++ b/src/app/thanks/page.tsx
@@ -1,0 +1,10 @@
+export default function ThanksPage() {
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center p-4 text-center">
+      <h1 className="font-serif text-4xl">Спасибо за заявку!</h1>
+      <p className="mt-4 text-lg text-black/70">
+        Мы свяжемся с вами в ближайшее время.
+      </p>
+    </div>
+  );
+}

--- a/src/components/FinalCTA.tsx
+++ b/src/components/FinalCTA.tsx
@@ -5,7 +5,7 @@ import { useQuiz } from "./QuizProvider";
 
 export function FinalCTA() {
   const { open } = useQuiz();
-  const [email, setEmail] = useState("")
+  const [email, setEmail] = useState("");
   const emailValid = /\S+@\S+\.\S+/.test(email);
   const [showError, setShowError] = useState(false);
   return (
@@ -32,7 +32,7 @@ export function FinalCTA() {
             <button
               className="button primary"
               onClick={() => {
-                if (emailValid) open();
+                if (emailValid) open(email);
                 else {
                   setShowError(true);
                   setTimeout(() => setShowError(false), 800);

--- a/src/components/Quiz.tsx
+++ b/src/components/Quiz.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import { useState } from "react";
+import { useRouter } from "next/navigation";
 
 interface QuizProps {
   onClose: () => void;
+  initialEmail: string;
 }
 
 // initial data structure
@@ -28,13 +30,13 @@ interface QuizData {
   marketplaces: string[];
   avoid_items: string[];
   footwear_pref?: string;
-  contact_type: "phone" | "email";
   contact_value: string;
   consent_personal: boolean;
   consent_marketing: boolean;
 }
 
-export function Quiz({ onClose }: QuizProps) {
+export function Quiz({ onClose, initialEmail }: QuizProps) {
+  const router = useRouter();
   const totalSteps = 6;
   const [step, setStep] = useState(0);
   const [tab, setTab] = useState<"photo" | "params">("photo");
@@ -48,8 +50,7 @@ export function Quiz({ onClose }: QuizProps) {
     brands_known: ["", "", ""],
     marketplaces: [],
     avoid_items: [],
-    contact_type: "email",
-    contact_value: "",
+    contact_value: initialEmail,
     consent_personal: false,
     consent_marketing: false,
   });
@@ -63,12 +64,13 @@ export function Quiz({ onClose }: QuizProps) {
 
   const handleSubmit = () => {
     console.log("quiz submit", data);
+    router.push("/thanks");
     onClose();
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4">
-      <div className="max-h-full w-full max-w-md overflow-auto rounded-md bg-white p-4">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm p-4">
+      <div className="max-h-full w-full max-w-md overflow-auto rounded-xl bg-white p-6 shadow-lg">
         {/* progress */}
         <div className="mb-4 flex items-center justify-between text-sm">
           <div>
@@ -96,7 +98,10 @@ export function Quiz({ onClose }: QuizProps) {
                 { value: "weekend", label: "Выходные" },
                 { value: "season_update", label: "Сезон" },
               ].map((g) => (
-                <label key={g.value} className="flex items-center gap-2 rounded border p-2">
+                <label
+                  key={g.value}
+                  className="flex cursor-pointer items-center gap-2 rounded-md border p-2 transition hover:bg-gray-50"
+                >
                   <input
                     type="radio"
                     name="goal"
@@ -443,48 +448,10 @@ export function Quiz({ onClose }: QuizProps) {
 
         {step === 5 && (
           <div>
-            <h2 className="mb-4 text-lg font-semibold">Куда прислать подборку?</h2>
-            <div className="mb-4 space-y-2">
-              <label className="flex items-center gap-2">
-                <input
-                  type="radio"
-                  name="contact_type"
-                  value="phone"
-                  checked={data.contact_type === "phone"}
-                  onChange={() => update({ contact_type: "phone" })}
-                />
-                Телефон
-              </label>
-              <label className="flex items-center gap-2">
-                <input
-                  type="radio"
-                  name="contact_type"
-                  value="email"
-                  checked={data.contact_type === "email"}
-                  onChange={() => update({ contact_type: "email" })}
-                />
-                Email
-              </label>
-            </div>
-            <div className="mb-4">
-              {data.contact_type === "phone" ? (
-                <input
-                  type="tel"
-                  placeholder="+7 (___) ___-__-__"
-                  className="input w-full"
-                  value={data.contact_value}
-                  onChange={(e) => update({ contact_value: e.target.value })}
-                />
-              ) : (
-                <input
-                  type="email"
-                  placeholder="you@example.com"
-                  className="input w-full"
-                  value={data.contact_value}
-                  onChange={(e) => update({ contact_value: e.target.value })}
-                />
-              )}
-            </div>
+            <h2 className="mb-4 text-lg font-semibold">Почти готово!</h2>
+            <p className="mb-4 text-sm text-gray-600">
+              Мы отправим подборку на {data.contact_value}. Подтвердите согласие:
+            </p>
             <label className="mb-2 flex items-center gap-2">
               <input
                 type="checkbox"
@@ -528,7 +495,7 @@ export function Quiz({ onClose }: QuizProps) {
             <button
               className="button primary"
               onClick={handleSubmit}
-              disabled={!data.consent_personal || !data.contact_value}
+              disabled={!data.consent_personal}
             >
               Получить 3 лука
             </button>

--- a/src/components/QuizProvider.tsx
+++ b/src/components/QuizProvider.tsx
@@ -4,13 +4,14 @@ import { createContext, useContext, useEffect, useState, ReactNode } from "react
 import { Quiz } from "./Quiz";
 
 interface QuizContextValue {
-  open: () => void;
+  open: (email: string) => void;
 }
 
 const QuizContext = createContext<QuizContextValue | undefined>(undefined);
 
 export function QuizProvider({ children }: { children: ReactNode }) {
   const [isOpen, setIsOpen] = useState(false);
+  const [initialEmail, setInitialEmail] = useState("");
 
   useEffect(() => {
     if (isOpen && typeof window !== "undefined") {
@@ -21,9 +22,16 @@ export function QuizProvider({ children }: { children: ReactNode }) {
   }, [isOpen]);
 
   return (
-    <QuizContext.Provider value={{ open: () => setIsOpen(true) }}>
+    <QuizContext.Provider
+      value={{
+        open: (email: string) => {
+          setInitialEmail(email);
+          setIsOpen(true);
+        },
+      }}
+    >
       {children}
-      {isOpen && <Quiz onClose={() => setIsOpen(false)} />}
+      {isOpen && <Quiz initialEmail={initialEmail} onClose={() => setIsOpen(false)} />}
     </QuizContext.Provider>
   );
 }


### PR DESCRIPTION
## Summary
- Redirect quiz completion to a new thank-you page
- Capture email at quiz launch and remove phone/email fields from final step
- Refresh quiz styling with backdrop blur, rounded panels and hover effects

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68abfce64608832cb6b02ead75f80e47