### PR TITLE
Add thank-you page and refine quiz UI

### DIFF
--- a/src/app/thanks/page.tsx
+++ b/src/app/thanks/page.tsx
@@ -1,0 +1,13 @@
+import Link from "next/link";
+
+export default function ThanksPage() {
+  return (
+    <div className="container py-20 text-center">
+      <h1 className="h1 mb-4">Спасибо за заявку!</h1>
+      <p className="mb-6 text-lg">Мы получили ваши ответы и скоро свяжемся с вами.</p>
+      <Link href="/" className="button primary">
+        На главную
+      </Link>
+    </div>
+  );
+}

--- a/src/components/Quiz.tsx
+++ b/src/components/Quiz.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useRouter } from "next/navigation";
 
 interface QuizProps {
   onClose: () => void;
@@ -28,8 +29,6 @@ interface QuizData {
   marketplaces: string[];
   avoid_items: string[];
   footwear_pref?: string;
-  contact_type: "phone" | "email";
-  contact_value: string;
   consent_personal: boolean;
   consent_marketing: boolean;
 }
@@ -48,8 +47,6 @@ export function Quiz({ onClose }: QuizProps) {
     brands_known: ["", "", ""],
     marketplaces: [],
     avoid_items: [],
-    contact_type: "email",
-    contact_value: "",
     consent_personal: false,
     consent_marketing: false,
   });
@@ -61,14 +58,16 @@ export function Quiz({ onClose }: QuizProps) {
 
   const update = (fields: Partial<QuizData>) => setData((d) => ({ ...d, ...fields }));
 
+  const router = useRouter();
   const handleSubmit = () => {
     console.log("quiz submit", data);
     onClose();
+    router.push("/thanks");
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4">
-      <div className="max-h-full w-full max-w-md overflow-auto rounded-md bg-white p-4">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4 backdrop-blur-sm">
+      <div className="max-h-full w-full max-w-md overflow-auto rounded-xl bg-[var(--bg-base)] p-6 shadow-lg">
         {/* progress */}
         <div className="mb-4 flex items-center justify-between text-sm">
           <div>
@@ -78,9 +77,9 @@ export function Quiz({ onClose }: QuizProps) {
             ✕
           </button>
         </div>
-        <div className="mb-4 h-1 w-full bg-gray-200">
+        <div className="mb-6 h-2 w-full rounded-full bg-[var(--border)]">
           <div
-            className="h-full bg-black"
+            className="h-full rounded-full bg-[var(--brand-500)] transition-all"
             style={{ width: `${((step + 1) / totalSteps) * 100}%` }}
           />
         </div>
@@ -443,48 +442,10 @@ export function Quiz({ onClose }: QuizProps) {
 
         {step === 5 && (
           <div>
-            <h2 className="mb-4 text-lg font-semibold">Куда прислать подборку?</h2>
-            <div className="mb-4 space-y-2">
-              <label className="flex items-center gap-2">
-                <input
-                  type="radio"
-                  name="contact_type"
-                  value="phone"
-                  checked={data.contact_type === "phone"}
-                  onChange={() => update({ contact_type: "phone" })}
-                />
-                Телефон
-              </label>
-              <label className="flex items-center gap-2">
-                <input
-                  type="radio"
-                  name="contact_type"
-                  value="email"
-                  checked={data.contact_type === "email"}
-                  onChange={() => update({ contact_type: "email" })}
-                />
-                Email
-              </label>
-            </div>
-            <div className="mb-4">
-              {data.contact_type === "phone" ? (
-                <input
-                  type="tel"
-                  placeholder="+7 (___) ___-__-__"
-                  className="input w-full"
-                  value={data.contact_value}
-                  onChange={(e) => update({ contact_value: e.target.value })}
-                />
-              ) : (
-                <input
-                  type="email"
-                  placeholder="you@example.com"
-                  className="input w-full"
-                  value={data.contact_value}
-                  onChange={(e) => update({ contact_value: e.target.value })}
-                />
-              )}
-            </div>
+            <h2 className="mb-4 text-lg font-semibold">Почти готово!</h2>
+            <p className="mb-4 text-sm text-gray-600">
+              Мы отправим подборку на вашу почту. Подтвердите согласия:
+            </p>
             <label className="mb-2 flex items-center gap-2">
               <input
                 type="checkbox"
@@ -528,7 +489,7 @@ export function Quiz({ onClose }: QuizProps) {
             <button
               className="button primary"
               onClick={handleSubmit}
-              disabled={!data.consent_personal || !data.contact_value}
+              disabled={!data.consent_personal}
             >
               Получить 3 лука
             </button>


### PR DESCRIPTION
## Summary
- redirect quiz completion to a new thank-you page
- remove contact inputs and tidy final step
- polish quiz overlay and progress bar styling

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68abfce64608832cb6b02ead75f80e47