### PR TITLE
Track Yandex Metrica events for quiz and subscriptions

### DIFF
--- a/src/app/api/quiz/route.ts
+++ b/src/app/api/quiz/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { getAdminClient } from "@/lib/supabase-server";
 import { notifyTG } from "@/lib/notify";
 import { quizSchema } from "@/lib/validators";
+import { trackMetrica } from "@/lib/metrica";
 
 const rateMap = new Map<string, { count: number; time: number }>();
 function rateLimit(ip: string, limit = 20, windowMs = 60_000) {
@@ -64,6 +65,8 @@ export async function POST(req: Request) {
       lead_id: leadId,
       session_id: sessionId,
     });
+
+    trackMetrica(eventName);
 
     if (complete) {
       await notifyTG(`✅ Квиз завершён${email ? `: ${email}` : ""} (${sessionId})`);

--- a/src/app/api/subscribe/route.ts
+++ b/src/app/api/subscribe/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { getAdminClient } from "@/lib/supabase-server";
 import { notifyTG } from "@/lib/notify";
 import { subscribeSchema } from "@/lib/validators";
+import { trackMetrica } from "@/lib/metrica";
 
 const rateMap = new Map<string, { count: number; time: number }>();
 
@@ -42,6 +43,8 @@ export async function POST(req: Request) {
       payload: { source },
       lead_id: lead.id,
     });
+
+    trackMetrica("lead_submitted");
 
     await notifyTG(`🆕 Новый лид: ${email}${source ? ` (${source})` : ""}`);
 

--- a/src/lib/metrica.ts
+++ b/src/lib/metrica.ts
@@ -1,0 +1,7 @@
+export function trackMetrica(event: string) {
+  const id = process.env.NEXT_PUBLIC_YANDEX_METRICA_ID;
+  if (!id || process.env.NODE_ENV === "test") return;
+  const url = new URL(`https://mc.yandex.ru/watch/${id}`);
+  url.searchParams.set("event", event);
+  fetch(url.toString()).catch(() => {});
+}


### PR DESCRIPTION
## Summary
- send Supabase events to Yandex Metrica
- track quiz steps and lead submissions in Metrica using consistent names

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac032b12bc832cb05ab9a0a571b235