### PR TITLE
Ensure Supabase writes throw on error

### DIFF
--- a/src/app/api/subscribe/route.ts
+++ b/src/app/api/subscribe/route.ts
@@ -37,11 +37,14 @@ export async function POST(req: Request) {
       .single();
     if (error) throw error;
 
-    await supabase.from("events").insert({
-      name: "lead_submitted",
-      payload: { source },
-      lead_id: lead.id,
-    });
+    const { error: eventError } = await supabase
+      .from("events")
+      .insert({
+        name: "lead_submitted",
+        payload: { source },
+        lead_id: lead.id,
+      });
+    if (eventError) throw eventError;
 
     await notifyTG(`🆕 Новый лид: ${email}${source ? ` (${source})` : ""}`);
 


### PR DESCRIPTION
## Summary
- add explicit error checks for quiz session, answer, and event writes
- add error check when logging new lead events

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac032e02bc832cb54a935f5146410c