### PR TITLE
feat: stack goal options on small screens

### DIFF
--- a/src/components/Quiz.tsx
+++ b/src/components/Quiz.tsx
@@ -95,7 +95,7 @@ export function Quiz({ onClose }: QuizProps) {
         return (
           <div>
             <h2 className="mb-6 text-xl font-semibold">Под что собираем капсулу?</h2>
-            <div className="grid grid-cols-2 gap-3">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
               {[
                 { value: "office_casual", label: "Офис" },
                 { value: "date", label: "Свидание" },


### PR DESCRIPTION
## Summary
- make goal step grid single column on small screens for full-width items

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68aca8e6b784832c8d5b22b86ea37580