### PR TITLE
fix: prevent horizontal shift on mobile

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,8 +11,8 @@ export const metadata: Metadata = { /* ... */ };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="ru" data-theme="light">
-      <body className="bg-bg-base text-fg-primary font-sans antialiased">
+    <html lang="ru" data-theme="light" className="overflow-x-hidden">
+      <body className="bg-bg-base text-fg-primary font-sans antialiased overflow-x-hidden">
         <AnalyticsProvider>
           <QuizProvider>
             <Header />


### PR DESCRIPTION
## Summary
- prevent horizontal scrolling by hiding overflow on the `html` and `body`

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68acac4d83a8832c8c25996c374b586e