### PR TITLE
feat: redesign header layout

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,57 +1,76 @@
 "use client";
 
 import { useState } from "react";
-import Image from "next/image";
 import Link from "next/link";
 
 export function Header() {
   const [menuOpen, setMenuOpen] = useState(false);
   const navItems = [
-    { href: "#benefits", label: "Преимущества" },
-    { href: "#how", label: "Как это работает" },
-    { href: "#examples", label: "Примеры образов" },
-    { href: "#faq", label: "FAQ" },
-    { href: "#contacts", label: "Контакты" },
+    { href: "#products", label: "Products", dropdown: true },
+    { href: "#tech", label: "Our Proprietary Tech" },
+    { href: "#company", label: "Company" },
+    { href: "#resources", label: "Resources" },
   ];
 
   return (
     <>
       {/* Main header */}
-      <header className="bg-white/100 backdrop-blur sticky top-0 z-50 w-full">
+      <header className="bg-zinc-100 sticky top-0 z-50 w-full">
         <div className="container flex items-center justify-between py-4">
-          <Link href="/" className="flex items-center" aria-label="Stylist AI">
-            <Image src="/logo.svg" alt="Stylist AI" width={120} height={24} />
+          <Link href="/" className="text-xl font-semibold" aria-label="Aiuta">
+            AÏUTA
           </Link>
 
           {/* Desktop navigation */}
-          <nav className="hidden md:flex items-center gap-8">
+          <nav className="hidden md:flex items-center gap-8 bg-white border rounded-full px-6 py-2">
             {navItems.map((item) => (
               <Link
                 key={item.href}
                 href={item.href}
-                className="text-sm text-black/70 hover:text-black transition-colors"
+                className="flex items-center gap-1 text-sm text-black/70 hover:text-black transition-colors"
                 onClick={() => setMenuOpen(false)}
               >
                 {item.label}
+                {item.dropdown && (
+                  <svg
+                    className="h-4 w-4"
+                    viewBox="0 0 20 20"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    <polyline points="6 8 10 12 14 8" />
+                  </svg>
+                )}
               </Link>
             ))}
           </nav>
 
           <div className="flex items-center gap-4">
             <Link
-              href="#cta"
+              href="#demo"
               onClick={() => setMenuOpen(false)}
-              className="button primary hidden md:inline-flex"
+              className="hidden md:inline-flex items-center rounded-md border border-black px-4 py-2 text-sm hover:bg-black hover:text-white transition-colors"
             >
-              Попробовать бесплатно
+              Book a demo
             </Link>
             {/* Mobile hamburger */}
             <button
               className="md:hidden p-2"
               onClick={() => setMenuOpen((o) => !o)}
-              aria-label="Открыть меню"
+              aria-label="Open menu"
             >
-              <svg className="h-6 w-6" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <svg
+                className="h-6 w-6"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
                 <line x1="3" y1="6" x2="21" y2="6" />
                 <line x1="3" y1="12" x2="21" y2="12" />
                 <line x1="3" y1="18" x2="21" y2="18" />
@@ -75,11 +94,11 @@ export function Header() {
                 </Link>
               ))}
               <Link
-                href="#cta"
+                href="#demo"
                 className="button primary"
                 onClick={() => setMenuOpen(false)}
               >
-                Попробовать бесплатно
+                Book a demo
               </Link>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- redesign header with new navigation and branding
- add demo button and dropdown indicator for products

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68acb0f56440832c9d20d2e4dc5d9565