### PR TITLE
feat: add photo upload step

### DIFF
--- a/src/components/Quiz.tsx
+++ b/src/components/Quiz.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import StyleStep from "./quiz/StyleStep";
+import PhotoStep from "./quiz/PhotoStep";
 
 interface QuizProps {
   onClose: () => void;
@@ -65,6 +66,7 @@ export function Quiz({ onClose }: QuizProps) {
     marketplaces: [],
     avoid_items: [],
   });
+  const [photoValid, setPhotoValid] = useState(false);
 
   const next = () => setStep((s) => Math.min(s + 1, totalSteps - 1));
   const prev = () => setStep((s) => Math.max(s - 1, 0));
@@ -88,6 +90,14 @@ export function Quiz({ onClose }: QuizProps) {
       if (ymId) win.ym?.(Number(ymId), "reachGoal", event);
     }
   }, [stepId]);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
 
   const renderStep = () => {
     switch (stepId) {
@@ -150,22 +160,13 @@ export function Quiz({ onClose }: QuizProps) {
         );
       case "photo":
         return (
-          <div className="space-y-4">
-            <h2 className="mb-6 text-xl font-semibold">Фото</h2>
-            <input
-              type="file"
-              accept="image/png,image/jpeg,image/webp"
-              onChange={(e) => update({ photo: e.target.files?.[0] })}
-            />
-            <label className="flex items-center gap-2">
-              <input
-                type="checkbox"
-                checked={data.no_face}
-                onChange={(e) => update({ no_face: e.target.checked })}
-              />
-              Скрыть лицо
-            </label>
-          </div>
+          <PhotoStep
+            file={data.photo ?? null}
+            hideFace={data.no_face}
+            onChange={(f) => update({ photo: f })}
+            onHideFaceChange={(v) => update({ no_face: v })}
+            onValidChange={setPhotoValid}
+          />
         );
       case "body":
         return (
@@ -447,7 +448,7 @@ export function Quiz({ onClose }: QuizProps) {
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4 backdrop-blur-sm">
-      <div className="max-h-full w-full max-w-lg overflow-auto rounded-xl bg-white p-6 shadow-lg">
+      <div className="max-h-[90vh] w-full max-w-[720px] overflow-auto rounded-2xl bg-white p-6 sm:p-8 shadow-lg">
         {/* progress */}
         <div className="mb-6 flex items-center justify-between text-sm">
           <div>
@@ -457,7 +458,12 @@ export function Quiz({ onClose }: QuizProps) {
             ✕
           </button>
         </div>
-        <div className="mb-6 h-2 w-full overflow-hidden rounded-full bg-gray-200">
+        <div
+          className="mb-6 h-1.5 w-full overflow-hidden rounded-full bg-gray-200"
+          role="progressbar"
+          aria-valuenow={step + 1}
+          aria-valuemax={totalSteps}
+        >
           <div
             className="h-full rounded-full bg-[var(--brand-500)] transition-all"
             style={{ width: `${((step + 1) / totalSteps) * 100}%` }}
@@ -474,7 +480,11 @@ export function Quiz({ onClose }: QuizProps) {
             <span />
           )}
           {step < totalSteps - 1 ? (
-            <button className="button primary" onClick={next}>
+            <button
+              className="button primary"
+              onClick={next}
+              disabled={stepId === "photo" && !photoValid}
+            >
               Далее
             </button>
           ) : (

--- a/src/components/quiz/PhotoStep.tsx
+++ b/src/components/quiz/PhotoStep.tsx
@@ -1,0 +1,167 @@
+import { useEffect, useRef, useState } from "react";
+import clsx from "clsx";
+
+const ACCEPTED_TYPES = [
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "image/heic",
+  "image/heif",
+];
+
+export function validateFile(file: File): string | null {
+  if (!ACCEPTED_TYPES.includes(file.type)) {
+    return "Неподдерживаемый формат файла";
+  }
+  if (file.size > 15 * 1024 * 1024) {
+    return "Файл слишком большой. До 15 МБ";
+  }
+  return null;
+}
+
+interface PhotoStepProps {
+  file: File | null;
+  hideFace: boolean;
+  onChange: (file: File | null) => void;
+  onHideFaceChange: (v: boolean) => void;
+  onValidChange: (v: boolean) => void;
+}
+
+export default function PhotoStep({
+  file,
+  hideFace,
+  onChange,
+  onHideFaceChange,
+  onValidChange,
+}: PhotoStepProps) {
+  const [preview, setPreview] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [dragOver, setDragOver] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (file) {
+      const url = URL.createObjectURL(file);
+      setPreview(url);
+      setError(null);
+      onValidChange(true);
+      return () => URL.revokeObjectURL(url);
+    } else {
+      setPreview(null);
+      onValidChange(false);
+    }
+  }, [file, onValidChange]);
+
+  const handleFiles = (files: FileList | null) => {
+    if (!files || files.length === 0) return;
+    const f = files[0];
+    const err = validateFile(f);
+    if (err) {
+      setError(err);
+      onChange(null);
+      return;
+    }
+    onChange(f);
+  };
+
+  const openFile = () => inputRef.current?.click();
+
+  const dropProps = {
+    onDragOver: (e: React.DragEvent) => {
+      e.preventDefault();
+      setDragOver(true);
+    },
+    onDragLeave: (e: React.DragEvent) => {
+      e.preventDefault();
+      setDragOver(false);
+    },
+    onDrop: (e: React.DragEvent) => {
+      e.preventDefault();
+      setDragOver(false);
+      handleFiles(e.dataTransfer.files);
+    },
+  };
+
+  return (
+    <div className="space-y-4">
+      {!preview ? (
+        <div
+          {...dropProps}
+          role="button"
+          tabIndex={0}
+          onClick={openFile}
+          className={clsx(
+            "flex flex-col items-center justify-center rounded-lg border-2 border-dashed p-10 text-center cursor-pointer",
+            dragOver ? "bg-gray-50" : "bg-[#FAFAFC]",
+            error ? "border-red-500" : "border-[#D9DBE1]"
+          )}
+        >
+          <p className="mb-2 font-medium">
+            Перетащите фото сюда или выберите файл
+          </p>
+          <p className="text-sm text-gray-500">
+            JPG/PNG/HEIC/WEBP, до 15 МБ, лучше в полный рост
+          </p>
+          <button className="button mt-4" onClick={openFile}>
+            Выбрать файл
+          </button>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          <div className="relative overflow-hidden rounded-lg bg-gray-50">
+            <img
+              src={preview}
+              alt="Загруженное фото"
+              className={clsx(
+                "max-h-96 w-full object-contain",
+                hideFace && "blur-md"
+              )}
+            />
+            <div className="absolute inset-0 flex items-start justify-end gap-2 p-2">
+              <button className="button" onClick={openFile}>
+                Заменить фото
+              </button>
+              <button
+                className="button"
+                onClick={() => {
+                  onChange(null);
+                  setError(null);
+                }}
+              >
+                Удалить
+              </button>
+            </div>
+          </div>
+          {hideFace && (
+            <div className="text-xs text-gray-600">
+              Лицо будет скрыто на визуализациях
+            </div>
+          )}
+        </div>
+      )}
+      <input
+        ref={inputRef}
+        type="file"
+        accept="image/*"
+        capture="environment"
+        className="hidden"
+        onChange={(e) => handleFiles(e.target.files)}
+      />
+      <label className="flex items-center gap-2">
+        <input
+          type="checkbox"
+          checked={hideFace}
+          onChange={(e) => onHideFaceChange(e.target.checked)}
+        />
+        Скрыть лицо
+      </label>
+      {error && <div className="text-sm text-red-500">{error}</div>}
+      <ul className="list-disc space-y-1 pl-5 text-xs text-gray-500">
+        <li>Попросите ровную стойку, руки свободны</li>
+        <li>Хороший свет, без сильных теней</li>
+        <li>Одежда прилегающая — так точнее</li>
+      </ul>
+    </div>
+  );
+}
+

--- a/tests/photoStep.test.ts
+++ b/tests/photoStep.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { validateFile } from "../src/components/quiz/PhotoStep";
+
+function makeFile(type: string, size: number) {
+  return new File([new ArrayBuffer(size)], "test", { type });
+}
+
+describe("validateFile", () => {
+  it("rejects unsupported type", () => {
+    const err = validateFile(makeFile("image/gif", 1000));
+    expect(err).toBe("Неподдерживаемый формат файла");
+  });
+
+  it("rejects large file", () => {
+    const err = validateFile(makeFile("image/jpeg", 16 * 1024 * 1024));
+    expect(err).toBe("Файл слишком большой. До 15 МБ");
+  });
+
+  it("accepts valid file", () => {
+    const err = validateFile(makeFile("image/png", 1024));
+    expect(err).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- implement dedicated `PhotoStep` with drag-and-drop, preview and validation
- make quiz modal larger with accessible progress and Escape to close
- disable Next button until a valid photo is selected

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68acf0fcd6ac832cb5f7da7a9b272f81