### PR TITLE
feat: add photo upload step with drag and drop

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "next": "15.5.0",
     "react": "19.1.0",
     "react-dom": "19.1.0",
+    "react-dropzone": "^14.3.8",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       react-dom:
         specifier: 19.1.0
         version: 19.1.0(react@19.1.0)
+      react-dropzone:
+        specifier: ^14.3.8
+        version: 14.3.8(react@19.1.0)
       zod:
         specifier: ^3.23.8
         version: 3.25.76
@@ -982,6 +985,10 @@ packages:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
 
+  attr-accept@2.2.5:
+    resolution: {integrity: sha512-0bDNnY/u6pPwHDMoF0FieU354oBi0a8rD9FcsLwzcGWbc8KS8KPIi7y+s13OlVY+gMWc/9xEMUgNE6Qm8ZllYQ==}
+    engines: {node: '>=4'}
+
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
@@ -1342,6 +1349,10 @@ packages:
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
+
+  file-selector@2.1.2:
+    resolution: {integrity: sha512-QgXo+mXTe8ljeqUFaX3QVHc5osSItJ/Km+xpocx0aSqWGMSCf6qYs/VnzZgS864Pjn5iceMRFigeAV7AfTlaig==}
+    engines: {node: '>= 12'}
 
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
@@ -1887,6 +1898,12 @@ packages:
     resolution: {integrity: sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==}
     peerDependencies:
       react: ^19.1.0
+
+  react-dropzone@14.3.8:
+    resolution: {integrity: sha512-sBgODnq+lcA4P296DY4wacOZz3JFpD99fp+hb//iBO2HHnyeZU3FwWyXJ6salNpqQdsZrgMrotuko/BdJMV8Ug==}
+    engines: {node: '>= 10.13'}
+    peerDependencies:
+      react: '>= 16.8 || 18.0.0'
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -3083,6 +3100,8 @@ snapshots:
 
   async-function@1.0.0: {}
 
+  attr-accept@2.2.5: {}
+
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
@@ -3609,6 +3628,10 @@ snapshots:
     dependencies:
       flat-cache: 4.0.1
 
+  file-selector@2.1.2:
+    dependencies:
+      tslib: 2.8.1
+
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
@@ -4134,6 +4157,13 @@ snapshots:
     dependencies:
       react: 19.1.0
       scheduler: 0.26.0
+
+  react-dropzone@14.3.8(react@19.1.0):
+    dependencies:
+      attr-accept: 2.2.5
+      file-selector: 2.1.2
+      prop-types: 15.8.1
+      react: 19.1.0
 
   react-is@16.13.1: {}
 

--- a/src/components/Quiz.tsx
+++ b/src/components/Quiz.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import StyleStep from "./quiz/StyleStep";
+import PhotoStep from "./quiz/PhotoStep";
 
 interface QuizProps {
   onClose: () => void;
@@ -65,6 +66,9 @@ export function Quiz({ onClose }: QuizProps) {
     marketplaces: [],
     avoid_items: [],
   });
+
+  const [photoValid, setPhotoValid] = useState(!!data.photo);
+  const [photoProcessing, setPhotoProcessing] = useState(false);
 
   const next = () => setStep((s) => Math.min(s + 1, totalSteps - 1));
   const prev = () => setStep((s) => Math.max(s - 1, 0));
@@ -150,22 +154,14 @@ export function Quiz({ onClose }: QuizProps) {
         );
       case "photo":
         return (
-          <div className="space-y-4">
-            <h2 className="mb-6 text-xl font-semibold">Фото</h2>
-            <input
-              type="file"
-              accept="image/png,image/jpeg,image/webp"
-              onChange={(e) => update({ photo: e.target.files?.[0] })}
-            />
-            <label className="flex items-center gap-2">
-              <input
-                type="checkbox"
-                checked={data.no_face}
-                onChange={(e) => update({ no_face: e.target.checked })}
-              />
-              Скрыть лицо
-            </label>
-          </div>
+          <PhotoStep
+            file={data.photo}
+            hideFace={data.no_face}
+            onFileChange={(file) => update({ photo: file })}
+            onHideFaceChange={(hide) => update({ no_face: hide })}
+            onValidityChange={setPhotoValid}
+            onProcessingChange={setPhotoProcessing}
+          />
         );
       case "body":
         return (
@@ -457,7 +453,12 @@ export function Quiz({ onClose }: QuizProps) {
             ✕
           </button>
         </div>
-        <div className="mb-6 h-2 w-full overflow-hidden rounded-full bg-gray-200">
+        <div
+          className="mb-6 h-[6px] w-full overflow-hidden rounded-full bg-gray-200"
+          role="progressbar"
+          aria-valuenow={step + 1}
+          aria-valuemax={totalSteps}
+        >
           <div
             className="h-full rounded-full bg-[var(--brand-500)] transition-all"
             style={{ width: `${((step + 1) / totalSteps) * 100}%` }}
@@ -474,8 +475,19 @@ export function Quiz({ onClose }: QuizProps) {
             <span />
           )}
           {step < totalSteps - 1 ? (
-            <button className="button primary" onClick={next}>
-              Далее
+            <button
+              className="button primary disabled:opacity-50"
+              onClick={next}
+              disabled={stepId === "photo" && (!photoValid || photoProcessing)}
+            >
+              {stepId === "photo" && photoProcessing ? (
+                <span className="flex items-center gap-2">
+                  <span className="h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent" />
+                  Загрузка...
+                </span>
+              ) : (
+                "Далее"
+              )}
             </button>
           ) : (
             <button className="button primary" onClick={handleSubmit}>

--- a/src/components/quiz/PhotoStep.tsx
+++ b/src/components/quiz/PhotoStep.tsx
@@ -1,0 +1,192 @@
+import { useCallback, useEffect, useState } from "react";
+import { useDropzone } from "react-dropzone";
+
+interface PhotoStepProps {
+  file?: File | null;
+  hideFace: boolean;
+  onFileChange: (file: File | null) => void;
+  onHideFaceChange: (hide: boolean) => void;
+  onValidityChange: (valid: boolean) => void;
+  onProcessingChange?: (processing: boolean) => void;
+}
+
+const MAX_SIZE = 15 * 1024 * 1024; // 15MB
+const MIN_WIDTH = 800;
+const MIN_HEIGHT = 1200;
+
+export default function PhotoStep({
+  file,
+  hideFace,
+  onFileChange,
+  onHideFaceChange,
+  onValidityChange,
+  onProcessingChange,
+}: PhotoStepProps) {
+  const [preview, setPreview] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [processing, setProcessing] = useState(false);
+
+  const reset = () => {
+    setPreview(null);
+    setError(null);
+    onValidityChange(false);
+    setProcessing(false);
+    onProcessingChange?.(false);
+  };
+
+  useEffect(() => {
+    if (!file) {
+      reset();
+      return;
+    }
+    setProcessing(true);
+    onProcessingChange?.(true);
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      const url = e.target?.result as string;
+      const img = new Image();
+      img.onload = () => {
+        if (
+          img.width < MIN_WIDTH ||
+          img.height < MIN_HEIGHT ||
+          img.width * img.height < 1_000_000
+        ) {
+          setError("Фото низкого качества (слишком маленькое/размытое)");
+          setPreview(null);
+          onValidityChange(false);
+        } else {
+          setPreview(url);
+          setError(null);
+          onValidityChange(true);
+        }
+        setProcessing(false);
+        onProcessingChange?.(false);
+      };
+      img.onerror = () => {
+        setError("Не удалось обработать фото. Повторить?");
+        setProcessing(false);
+        onProcessingChange?.(false);
+        onValidityChange(false);
+      };
+      img.src = url;
+    };
+    reader.onerror = () => {
+      setError("Не удалось обработать фото. Повторить?");
+      setProcessing(false);
+      onProcessingChange?.(false);
+      onValidityChange(false);
+    };
+    reader.readAsDataURL(file);
+  }, [file, onValidityChange]);
+
+  const onDrop = useCallback(
+    (accepted: File[]) => {
+      const f = accepted[0];
+      onFileChange(f);
+    },
+    [onFileChange]
+  );
+
+  const {
+    getRootProps,
+    getInputProps,
+    isDragActive,
+  } = useDropzone({
+    accept: {
+      "image/jpeg": [],
+      "image/png": [],
+      "image/webp": [],
+      "image/heic": [],
+    },
+    maxSize: MAX_SIZE,
+    multiple: false,
+    onDrop,
+    onDropRejected: (rejections) => {
+      const err = rejections[0];
+      if (err.errors.some((e) => e.code === "file-too-large")) {
+        setError("Файл слишком большой. До 15 МБ");
+      } else {
+        setError("Неподдерживаемый формат файла");
+      }
+      onFileChange(null);
+      onValidityChange(false);
+    },
+  });
+
+  const handleRemove = () => {
+    onFileChange(null);
+    setPreview(null);
+    setError(null);
+    onValidityChange(false);
+    setProcessing(false);
+    onProcessingChange?.(false);
+  };
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-xl font-semibold">Фото</h2>
+      <div
+        {...getRootProps({
+          className:
+            "relative flex cursor-pointer flex-col items-center justify-center rounded-xl border-2 border-dashed border-[#D9DBE1] bg-[#FAFAFC] p-8 text-center focus:outline-none",
+          tabIndex: 0,
+        })}
+      >
+        <input
+          {...getInputProps({ accept: "image/*", capture: "environment" })}
+          aria-labelledby="upload-label"
+        />
+        {preview ? (
+          <div className="relative w-full">
+            <img
+              src={preview}
+              alt="Предпросмотр"
+              className="mx-auto max-h-80 w-full object-contain"
+            />
+            {hideFace && (
+              <div className="absolute inset-0 backdrop-blur-md" aria-hidden="true" />
+            )}
+            {processing && (
+              <div className="absolute inset-0 flex items-center justify-center bg-white/70">
+                <div className="h-8 w-8 animate-spin rounded-full border-2 border-gray-300 border-t-transparent" />
+              </div>
+            )}
+          </div>
+        ) : (
+          <div className="flex flex-col items-center gap-2" id="upload-label">
+            <span className="text-sm">Перетащите фото сюда или выберите файл</span>
+            <span className="text-xs text-gray-600">
+              JPG/PNG/HEIC/WEBP, до 15 МБ. Лучше — в полный рост при хорошем свете.
+            </span>
+            <button type="button" className="button mt-2">
+              Выбрать файл
+            </button>
+          </div>
+        )}
+        {isDragActive && !preview && (
+          <div className="absolute inset-0 rounded-xl border-2 border-[var(--brand-500)]" />
+        )}
+      </div>
+      <label className="flex items-center gap-2">
+        <input
+          type="checkbox"
+          checked={hideFace}
+          onChange={(e) => onHideFaceChange(e.target.checked)}
+        />
+        Скрыть лицо
+      </label>
+      {preview && (
+        <div className="flex gap-4">
+          <button type="button" className="text-sm underline" onClick={() => onFileChange(null)}>
+            Заменить фото
+          </button>
+          <button type="button" className="text-sm text-red-600 underline" onClick={handleRemove}>
+            Удалить
+          </button>
+        </div>
+      )}
+      {error && <p className="text-sm text-red-600">{error}</p>}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add drag-n-drop photo upload step with preview and hide face option
- disable Next button until image validation completes
- expose progress bar with ARIA attributes

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68acf0fcd6ac832cb5f7da7a9b272f81