### PR TITLE
feat: enhance quiz style step

### DIFF
--- a/public/quiz/styles/README.md
+++ b/public/quiz/styles/README.md
@@ -1,0 +1,1 @@
+Place style cover images here.

--- a/public/quiz/styles/examples/README.md
+++ b/public/quiz/styles/examples/README.md
@@ -1,0 +1,1 @@
+Place style example images here.


### PR DESCRIPTION
## Summary
- add dedicated quiz style options with up to two selections and auto-pick flow
- disable extra cards, show limit message, and confirm before leaving auto-pick
- provide examples modal, accessibility roles, and fallback images

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68acf4549398832ca5fa20144108bfc0