### PR TITLE
feat: add brand search and quiz endpoints

### DIFF
--- a/src/app/api/brands/popular/route.ts
+++ b/src/app/api/brands/popular/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server";
+import { BRANDS, BrandRecord } from "@/data/brands";
+import { prepareBrands } from "@/lib/brand-utils";
+
+if (!BRANDS[0].tokens) prepareBrands(BRANDS);
+
+const cache = new Map<string, { expires: number; data: any }>();
+const CACHE_TTL = 3_600_000; // 1 hour
+
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const tier = url.searchParams.get("tier") as BrandRecord["tier"] | null;
+  const region = url.searchParams.get("region") || "ru";
+  const limit = Math.min(Number(url.searchParams.get("limit") || 16), 50);
+
+  const cacheKey = `popular:${region}:${tier || "all"}:${limit}`;
+  const cached = cache.get(cacheKey);
+  if (cached && cached.expires > Date.now()) return NextResponse.json(cached.data);
+
+  const items = BRANDS.filter((b) => b.is_active !== false && (!tier || b.tier === tier))
+    .sort((a, b) => (b.popularity?.[region] || 0) - (a.popularity?.[region] || 0))
+    .slice(0, limit)
+    .map((b) => ({ id: b.id, name: b.name, tier: b.tier, logo_url: b.logo_url }));
+
+  const data = { items };
+  cache.set(cacheKey, { data, expires: Date.now() + CACHE_TTL });
+  return NextResponse.json(data);
+}

--- a/src/app/api/brands/search/route.ts
+++ b/src/app/api/brands/search/route.ts
@@ -1,0 +1,51 @@
+import { NextResponse } from "next/server";
+import { BRANDS, BrandRecord } from "@/data/brands";
+import { normalize, prepareBrands, trigramSimilarity, tierWeight } from "@/lib/brand-utils";
+
+// prepare tokens once
+if (!BRANDS[0].tokens) prepareBrands(BRANDS);
+
+const cache = new Map<string, { expires: number; data: any }>();
+const CACHE_TTL = 600_000; // 10 min
+
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const q = url.searchParams.get("q");
+  const tier = url.searchParams.get("tier") as BrandRecord["tier"] | null;
+  const region = url.searchParams.get("region") || "ru";
+  const limit = Math.min(Number(url.searchParams.get("limit") || 8), 20);
+
+  if (!q) return NextResponse.json({ message: "q is required" }, { status: 400 });
+  const qNorm = normalize(q);
+  if (qNorm.length < 2) return NextResponse.json({ message: "q too short" }, { status: 400 });
+
+  const cacheKey = `search:${region}:${tier || "all"}:${qNorm}:${limit}`;
+  const cached = cache.get(cacheKey);
+  if (cached && cached.expires > Date.now()) return NextResponse.json(cached.data);
+
+  const items = BRANDS.filter((b) => b.is_active !== false && (!tier || b.tier === tier))
+    .map((b) => {
+      const tokens = b.tokens || [];
+      const exact = tokens.includes(qNorm);
+      const prefix = tokens.some((t) => t.startsWith(qNorm));
+      let similarity = 0;
+      for (const t of tokens) similarity = Math.max(similarity, trigramSimilarity(t, qNorm));
+      const popularity = b.popularity?.[region] || 0;
+      const score =
+        10 * (exact ? 1 : 0) +
+        6 * (prefix ? 1 : 0) +
+        4 * similarity +
+        2 * popularity +
+        (tierWeight[b.tier] || 0);
+      return { b, score, similarity, exact, prefix };
+    })
+    .filter((r) => r.exact || r.prefix || r.similarity >= 0.35)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, limit)
+    .map((r) => ({ id: r.b.id, name: r.b.name, tier: r.b.tier, logo_url: r.b.logo_url }));
+
+  const data = { items };
+  cache.set(cacheKey, { data, expires: Date.now() + CACHE_TTL });
+
+  return NextResponse.json(data);
+}

--- a/src/app/api/quiz/[quiz_id]/brands/route.ts
+++ b/src/app/api/quiz/[quiz_id]/brands/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from "next/server";
+import { _getStore } from "@/app/api/quiz/brands/route";
+
+export async function GET(
+  req: Request,
+  { params }: { params: { quiz_id: string } }
+) {
+  const { quiz_id } = params;
+  const store = _getStore();
+  const data = store.get(quiz_id) || {
+    favorite_brand_ids: [],
+    custom_brand_names: [],
+    auto_pick_brands: false,
+  };
+  return NextResponse.json(data);
+}

--- a/src/app/api/quiz/brands/route.ts
+++ b/src/app/api/quiz/brands/route.ts
@@ -1,0 +1,68 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { BRANDS } from "@/data/brands";
+
+const schema = z.object({
+  quiz_id: z.string().uuid(),
+  favorite_brand_ids: z.array(z.string()).max(3).default([]),
+  custom_brand_names: z.array(z.string().min(2).max(50)).max(3).default([]),
+  auto_pick_brands: z.boolean().optional().default(false),
+});
+
+const store = new Map<string, { favorite_brand_ids: string[]; custom_brand_names: string[]; auto_pick_brands: boolean }>();
+const rateMap = new Map<string, { count: number; time: number }>();
+
+function rateLimit(key: string, limit = 5, windowMs = 60_000) {
+  const now = Date.now();
+  const entry = rateMap.get(key);
+  if (!entry || now - entry.time > windowMs) {
+    rateMap.set(key, { count: 1, time: now });
+    return true;
+  }
+  if (entry.count >= limit) return false;
+  entry.count++;
+  return true;
+}
+
+export async function POST(req: Request) {
+  try {
+    const body = await req.json();
+    const parsed = schema.safeParse(body);
+    if (!parsed.success) return NextResponse.json({ message: "Invalid payload" }, { status: 400 });
+    const { quiz_id, favorite_brand_ids, custom_brand_names, auto_pick_brands } = parsed.data;
+
+    if (!rateLimit(quiz_id)) return NextResponse.json({ message: "Too many requests" }, { status: 429 });
+
+    if (auto_pick_brands) {
+      store.set(quiz_id, { favorite_brand_ids: [], custom_brand_names: [], auto_pick_brands: true });
+      return NextResponse.json({
+        saved: { favorite_brand_ids: [], custom_brand_names: [], auto_pick_brands: true },
+      });
+    }
+
+    const uniqIds = Array.from(new Set(favorite_brand_ids));
+    const brands = uniqIds.map((id) => BRANDS.find((b) => b.id === id && b.is_active !== false));
+    if (brands.some((b) => !b))
+      return NextResponse.json({ message: "Invalid brand id" }, { status: 400 });
+
+    const total = uniqIds.length + custom_brand_names.length;
+    if (total > 3)
+      return NextResponse.json({ message: "Too many brands" }, { status: 400 });
+
+    store.set(quiz_id, {
+      favorite_brand_ids: uniqIds,
+      custom_brand_names,
+      auto_pick_brands: false,
+    });
+
+    return NextResponse.json({
+      saved: { favorite_brand_ids: uniqIds, custom_brand_names, auto_pick_brands: false },
+    });
+  } catch (e) {
+    return NextResponse.json({ message: "Internal error" }, { status: 500 });
+  }
+}
+
+export function _getStore() {
+  return store;
+}

--- a/src/data/brands.ts
+++ b/src/data/brands.ts
@@ -1,0 +1,66 @@
+export type BrandTier = "mass" | "premium" | "luxury";
+
+export interface BrandRecord {
+  id: string;
+  name: string;
+  slug: string;
+  tier: BrandTier;
+  aliases: string[];
+  logo_url?: string;
+  is_active?: boolean;
+  popularity?: Record<string, number>; // region -> score
+  tokens?: string[]; // normalized search tokens, filled at runtime
+}
+
+export const BRANDS: BrandRecord[] = [
+  {
+    id: "00000000-0000-0000-0000-000000000001",
+    name: "Zara",
+    slug: "zara",
+    tier: "mass",
+    aliases: ["zara", "зара"],
+    logo_url: undefined,
+    is_active: true,
+    popularity: { ru: 100 },
+  },
+  {
+    id: "00000000-0000-0000-0000-000000000002",
+    name: "COS",
+    slug: "cos",
+    tier: "premium",
+    aliases: ["cos", "косс", "cos stores"],
+    logo_url: undefined,
+    is_active: true,
+    popularity: { ru: 80 },
+  },
+  {
+    id: "00000000-0000-0000-0000-000000000003",
+    name: "Gucci",
+    slug: "gucci",
+    tier: "luxury",
+    aliases: ["gucci", "гуччи"],
+    logo_url: undefined,
+    is_active: true,
+    popularity: { ru: 90 },
+  },
+  {
+    id: "00000000-0000-0000-0000-000000000004",
+    name: "H&M",
+    slug: "h-m",
+    tier: "mass",
+    aliases: ["h&m", "hm", "эйчэм"],
+    logo_url: undefined,
+    is_active: true,
+    popularity: { ru: 70 },
+  },
+  {
+    id: "00000000-0000-0000-0000-000000000005",
+    name: "Prada",
+    slug: "prada",
+    tier: "luxury",
+    aliases: ["prada", "прада"],
+    logo_url: undefined,
+    is_active: true,
+    popularity: { ru: 85 },
+  },
+];

--- a/src/lib/brand-utils.ts
+++ b/src/lib/brand-utils.ts
@@ -1,0 +1,93 @@
+import type { BrandRecord } from "@/data/brands";
+
+const ruToEn: Record<string, string> = {
+  а: "a",
+  б: "b",
+  в: "v",
+  г: "g",
+  д: "d",
+  е: "e",
+  ё: "e",
+  ж: "zh",
+  з: "z",
+  и: "i",
+  й: "y",
+  к: "k",
+  л: "l",
+  м: "m",
+  н: "n",
+  о: "o",
+  п: "p",
+  р: "r",
+  с: "s",
+  т: "t",
+  у: "u",
+  ф: "f",
+  х: "h",
+  ц: "ts",
+  ч: "ch",
+  ш: "sh",
+  щ: "sch",
+  ъ: "",
+  ы: "y",
+  ь: "",
+  э: "e",
+  ю: "yu",
+  я: "ya",
+};
+
+export function transliterate(input: string): string {
+  return input
+    .split("")
+    .map((ch) => {
+      const lower = ch.toLowerCase();
+      const t = ruToEn[lower];
+      if (!t) return ch;
+      return t;
+    })
+    .join("");
+}
+
+export function normalize(input: string): string {
+  return transliterate(input)
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "") // remove accents
+    .replace(/[.,'"\-_\//]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function prepareBrands(brands: BrandRecord[]) {
+  for (const b of brands) {
+    const tokens = new Set<string>();
+    tokens.add(normalize(b.name));
+    for (const a of b.aliases) tokens.add(normalize(a));
+    b.tokens = Array.from(tokens);
+  }
+}
+
+function trigrams(s: string): string[] {
+  const padded = `  ${s} `;
+  const arr: string[] = [];
+  for (let i = 0; i < padded.length - 2; i++) {
+    arr.push(padded.slice(i, i + 3));
+  }
+  return arr;
+}
+
+export function trigramSimilarity(a: string, b: string): number {
+  const aTri = trigrams(a);
+  const bTri = trigrams(b);
+  const setA = new Set(aTri);
+  const setB = new Set(bTri);
+  let inter = 0;
+  for (const t of setA) if (setB.has(t)) inter++;
+  return (2 * inter) / (setA.size + setB.size);
+}
+
+export const tierWeight: Record<string, number> = {
+  luxury: 2,
+  premium: 1,
+  mass: 0,
+};

--- a/tests/brands.api.test.ts
+++ b/tests/brands.api.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from "vitest";
+import { GET as searchGet } from "../src/app/api/brands/search/route";
+import { GET as popularGet } from "../src/app/api/brands/popular/route";
+import { POST as saveBrandsPost } from "../src/app/api/quiz/brands/route";
+import { GET as quizBrandsGet } from "../src/app/api/quiz/[quiz_id]/brands/route";
+import { BRANDS } from "../src/data/brands";
+
+const zaraId = BRANDS.find((b) => b.name === "Zara")!.id;
+const cosId = BRANDS.find((b) => b.name === "COS")!.id;
+
+describe("/api/brands/search", () => {
+  it("finds Zara by typo and transliteration", async () => {
+    const res = await searchGet(new Request("http://test/api/brands/search?q=zarra"));
+    expect(res.status).toBe(200);
+    const json: any = await res.json();
+    expect(json.items[0].name).toBe("Zara");
+
+    const res2 = await searchGet(new Request("http://test/api/brands/search?q=зара"));
+    const json2: any = await res2.json();
+    expect(json2.items[0].name).toBe("Zara");
+  });
+
+  it("handles RU to EN for COS", async () => {
+    const res = await searchGet(new Request("http://test/api/brands/search?q=косс"));
+    const json: any = await res.json();
+    expect(json.items[0].name).toBe("COS");
+  });
+
+  it("respects tier filter", async () => {
+    const res = await searchGet(new Request("http://test/api/brands/search?q=zara&tier=premium"));
+    const json: any = await res.json();
+    expect(json.items.length).toBe(0);
+  });
+
+  it("returns empty for junk", async () => {
+    const res = await searchGet(new Request("http://test/api/brands/search?q=zzzqqq"));
+    const json: any = await res.json();
+    expect(json.items.length).toBe(0);
+  });
+});
+
+describe("/api/brands/popular", () => {
+  it("returns popular premium brands", async () => {
+    const res = await popularGet(new Request("http://test/api/brands/popular?tier=premium&limit=1"));
+    const json: any = await res.json();
+    expect(json.items.length).toBe(1);
+    expect(json.items[0].tier).toBe("premium");
+  });
+});
+
+describe("quiz brand selection", () => {
+  const quizId = "123e4567-e89b-12d3-a456-426614174000";
+
+  it("saves and retrieves selection", async () => {
+    const res = await saveBrandsPost(
+      new Request("http://test/api/quiz/brands", {
+        method: "POST",
+        body: JSON.stringify({
+          quiz_id: quizId,
+          favorite_brand_ids: [zaraId, cosId],
+          custom_brand_names: ["Local"],
+          auto_pick_brands: false,
+        }),
+      })
+    );
+    expect(res.status).toBe(200);
+    const saved: any = await res.json();
+    expect(saved.saved.favorite_brand_ids).toHaveLength(2);
+
+    const res2 = await quizBrandsGet(
+      new Request(`http://test/api/quiz/${quizId}/brands`),
+      { params: { quiz_id: quizId } }
+    );
+    expect(res2.status).toBe(200);
+    const getJson: any = await res2.json();
+    expect(getJson.favorite_brand_ids).toHaveLength(2);
+    expect(getJson.custom_brand_names[0]).toBe("Local");
+  });
+
+  it("enforces limit", async () => {
+    const res = await saveBrandsPost(
+      new Request("http://test/api/quiz/brands", {
+        method: "POST",
+        body: JSON.stringify({
+          quiz_id: quizId,
+          favorite_brand_ids: [zaraId, cosId, zaraId],
+          custom_brand_names: ["One", "Two"],
+        }),
+      })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("handles auto pick", async () => {
+    const res = await saveBrandsPost(
+      new Request("http://test/api/quiz/brands", {
+        method: "POST",
+        body: JSON.stringify({ quiz_id: quizId, auto_pick_brands: true }),
+      })
+    );
+    expect(res.status).toBe(200);
+    const res2 = await quizBrandsGet(
+      new Request(`http://test/api/quiz/${quizId}/brands`),
+      { params: { quiz_id: quizId } }
+    );
+    const json: any = await res2.json();
+    expect(json.auto_pick_brands).toBe(true);
+    expect(json.favorite_brand_ids.length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add canonical brand dataset and utilities for transliteration and trigram scoring
- implement /api/brands/search and /api/brands/popular with caching and tier/region filters
- allow quiz step to save and retrieve brand selections with validation and rate limiting

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68acfabb3a2c832cb9954f8c4eeedbb8