### PR TITLE
feat: add brand selection API

### DIFF
--- a/scripts/supabase.sql
+++ b/scripts/supabase.sql
@@ -42,3 +42,78 @@ create policy srv_all_quiz_answers on quiz_answers for all
   to service_role using (true) with check (true);
 create policy srv_all_events on events for all
   to service_role using (true) with check (true);
+
+-- Brands and quiz brand selection
+create extension if not exists pg_trgm;
+create extension if not exists unaccent;
+
+create table if not exists brands (
+  id uuid primary key default gen_random_uuid(),
+  name text not null,
+  tier text not null check (tier in ('mass','premium','luxury')),
+  logo_url text,
+  is_active boolean not null default true
+);
+
+create table if not exists brand_aliases (
+  id bigserial primary key,
+  brand_id uuid not null references brands(id) on delete cascade,
+  alias text not null
+);
+
+create table if not exists brand_popularity (
+  brand_id uuid not null references brands(id) on delete cascade,
+  region text not null,
+  score integer not null default 0,
+  primary key (brand_id, region)
+);
+
+create table if not exists quiz_brand_selection (
+  id bigserial primary key,
+  quiz_id uuid not null,
+  brand_id uuid references brands(id),
+  source text not null,
+  order_index smallint not null,
+  created_at timestamptz not null default now()
+);
+create index if not exists quiz_brand_selection_quiz_idx on quiz_brand_selection (quiz_id);
+
+create table if not exists quiz_custom_brands (
+  id bigserial primary key,
+  quiz_id uuid not null,
+  name text not null check (char_length(name) between 2 and 50),
+  created_at timestamptz not null default now()
+);
+create index if not exists quiz_custom_brands_quiz_idx on quiz_custom_brands (quiz_id);
+
+create table if not exists quiz_brand_flags (
+  quiz_id uuid primary key,
+  auto_pick boolean not null default false,
+  updated_at timestamptz not null default now()
+);
+
+-- Simple search function used by the API
+create or replace function search_brands(q text, lim int default 8, p_tier text default null)
+returns table (id uuid, name text, tier text, logo_url text) as $$
+  select distinct b.id, b.name, b.tier, b.logo_url
+  from brands b
+  left join brand_aliases a on a.brand_id = b.id
+  where b.is_active
+    and (unaccent(lower(b.name)) like unaccent(lower(q)) || '%'
+      or unaccent(lower(a.alias)) like unaccent(lower(q)) || '%')
+    and (p_tier is null or b.tier = p_tier)
+  order by b.name
+  limit lim;
+$$ language sql stable;
+
+create or replace function get_popular_brands(p_region text, p_tier text default null, lim int default 16)
+returns table (id uuid, name text, tier text, logo_url text) as $$
+  select b.id, b.name, b.tier, b.logo_url
+  from brand_popularity p
+  join brands b on b.id = p.brand_id
+  where b.is_active
+    and p.region = p_region
+    and (p_tier is null or b.tier = p_tier)
+  order by p.score desc
+  limit lim;
+$$ language sql stable;

--- a/src/app/api/brands/popular/route.ts
+++ b/src/app/api/brands/popular/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from "next/server";
+import { getAdminClient } from "@/lib/supabase-server";
+
+type BrandItem = { id: string; name: string; tier: string; logo_url: string | null };
+const cache = new Map<string, { data: BrandItem[]; expires: number }>();
+
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const limit = Math.min(parseInt(url.searchParams.get("limit") || "16", 10), 50);
+  const tier = url.searchParams.get("tier") || null;
+  const region = url.searchParams.get("region") || "ru";
+
+  const key = `popular:${region}:${tier || "all"}:${limit}`;
+  const now = Date.now();
+  const cached = cache.get(key);
+  if (cached && cached.expires > now) return NextResponse.json({ items: cached.data });
+
+  const supabase = getAdminClient();
+  const { data, error } = await supabase.rpc("get_popular_brands", {
+    p_region: region,
+    p_tier: tier,
+    lim: limit,
+  });
+  if (error) {
+    console.error(error);
+    return NextResponse.json({ ok: false, message: "Internal error" }, { status: 500 });
+  }
+
+  cache.set(key, { data: data || [], expires: now + 60 * 60 * 1000 });
+  return NextResponse.json({ items: data || [] });
+}

--- a/src/app/api/brands/search/route.ts
+++ b/src/app/api/brands/search/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from "next/server";
+import { getAdminClient } from "@/lib/supabase-server";
+
+const rateMap = new Map<string, { count: number; time: number }>();
+function rateLimit(key: string, limit = 20, windowMs = 60_000) {
+  const now = Date.now();
+  const entry = rateMap.get(key);
+  if (!entry || now - entry.time > windowMs) {
+    rateMap.set(key, { count: 1, time: now });
+    return true;
+  }
+  if (entry.count >= limit) return false;
+  entry.count++;
+  return true;
+}
+
+type BrandItem = { id: string; name: string; tier: string; logo_url: string | null };
+const cache = new Map<string, { data: BrandItem[]; expires: number }>();
+
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const q = url.searchParams.get("q")?.trim() || "";
+  if (q.length < 2)
+    return NextResponse.json({ ok: false, message: "Query too short" }, { status: 400 });
+
+  const limit = Math.min(parseInt(url.searchParams.get("limit") || "8", 10), 20);
+  const tier = url.searchParams.get("tier") || null;
+  const region = url.searchParams.get("region") || "ru";
+
+  const ip = req.headers.get("x-forwarded-for")?.split(",")[0] || "unknown";
+  if (!rateLimit(ip))
+    return NextResponse.json({ ok: false, message: "Too many requests" }, { status: 429 });
+
+  const key = `search:${region}:${tier || "all"}:${q.toLowerCase()}`;
+  const now = Date.now();
+  const cached = cache.get(key);
+  if (cached && cached.expires > now) return NextResponse.json({ items: cached.data });
+
+  const supabase = getAdminClient();
+  const { data, error } = await supabase.rpc("search_brands", {
+    q,
+    lim: limit,
+    p_tier: tier,
+  });
+  if (error) {
+    console.error(error);
+    return NextResponse.json({ ok: false, message: "Internal error" }, { status: 500 });
+  }
+
+  cache.set(key, { data: data || [], expires: now + 10 * 60 * 1000 });
+  return NextResponse.json({ items: data || [] });
+}

--- a/src/app/api/quiz/[quizId]/brands/route.ts
+++ b/src/app/api/quiz/[quizId]/brands/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from "next/server";
+import { getAdminClient } from "@/lib/supabase-server";
+
+export async function GET(req: Request, { params }: { params: { quizId: string } }) {
+  const { quizId } = params;
+  const supabase = getAdminClient();
+
+  const { data: flag } = await supabase
+    .from("quiz_brand_flags")
+    .select("auto_pick")
+    .eq("quiz_id", quizId)
+    .maybeSingle();
+
+  const { data: selections } = await supabase
+    .from("quiz_brand_selection")
+    .select("brand_id, order_index")
+    .eq("quiz_id", quizId)
+    .order("order_index", { ascending: true });
+
+  const { data: customs } = await supabase
+    .from("quiz_custom_brands")
+    .select("name")
+    .eq("quiz_id", quizId);
+
+  return NextResponse.json({
+    favorite_brand_ids: selections?.map((s) => s.brand_id) || [],
+    custom_brand_names: customs?.map((c) => c.name) || [],
+    auto_pick_brands: flag?.auto_pick || false,
+  });
+}

--- a/src/app/api/quiz/brands/route.ts
+++ b/src/app/api/quiz/brands/route.ts
@@ -1,0 +1,83 @@
+import { NextResponse } from "next/server";
+import { getAdminClient } from "@/lib/supabase-server";
+import { quizBrandsSchema } from "@/lib/validators";
+
+const rateMap = new Map<string, { count: number; time: number }>();
+function rateLimit(key: string, limit = 5, windowMs = 60_000) {
+  const now = Date.now();
+  const entry = rateMap.get(key);
+  if (!entry || now - entry.time > windowMs) {
+    rateMap.set(key, { count: 1, time: now });
+    return true;
+  }
+  if (entry.count >= limit) return false;
+  entry.count++;
+  return true;
+}
+
+export async function POST(req: Request) {
+  try {
+    const json = await req.json();
+    const parsed = quizBrandsSchema.safeParse(json);
+    if (!parsed.success)
+      return NextResponse.json({ ok: false, message: "Invalid payload" }, { status: 400 });
+    const { quiz_id, favorite_brand_ids, custom_brand_names, auto_pick_brands } = parsed.data;
+
+    if (!rateLimit(quiz_id))
+      return NextResponse.json({ ok: false, message: "Too many requests" }, { status: 429 });
+
+    if (favorite_brand_ids.length + custom_brand_names.length > 3)
+      return NextResponse.json({ ok: false, message: "Too many brands" }, { status: 400 });
+
+    const supabase = getAdminClient();
+
+    if (auto_pick_brands) {
+      await supabase.from("quiz_brand_selection").delete().eq("quiz_id", quiz_id);
+      await supabase.from("quiz_custom_brands").delete().eq("quiz_id", quiz_id);
+      await supabase.from("quiz_brand_flags").upsert({ quiz_id, auto_pick: true });
+      return NextResponse.json({
+        saved: { favorite_brand_ids: [], custom_brand_names: [], auto_pick_brands: true },
+      });
+    }
+
+    if (favorite_brand_ids.length > 0) {
+      const { data: brands, error: brandErr } = await supabase
+        .from("brands")
+        .select("id")
+        .in("id", favorite_brand_ids)
+        .eq("is_active", true);
+      if (brandErr) throw brandErr;
+      if (!brands || brands.length !== favorite_brand_ids.length)
+        return NextResponse.json({ ok: false, message: "Invalid brand id" }, { status: 400 });
+    }
+
+    await supabase.from("quiz_brand_selection").delete().eq("quiz_id", quiz_id);
+    await supabase.from("quiz_custom_brands").delete().eq("quiz_id", quiz_id);
+
+    if (favorite_brand_ids.length > 0) {
+      await supabase.from("quiz_brand_selection").insert(
+        favorite_brand_ids.map((id, idx) => ({
+          quiz_id,
+          brand_id: id,
+          source: "search",
+          order_index: idx,
+        }))
+      );
+    }
+
+    if (custom_brand_names.length > 0) {
+      await supabase.from("quiz_custom_brands").insert(
+        custom_brand_names.map((name) => ({ quiz_id, name }))
+      );
+    }
+
+    await supabase.from("quiz_brand_flags").upsert({ quiz_id, auto_pick: false });
+
+    return NextResponse.json({
+      saved: { favorite_brand_ids, custom_brand_names, auto_pick_brands: false },
+    });
+  } catch (e) {
+    console.error(e);
+    return NextResponse.json({ ok: false, message: "Internal error" }, { status: 500 });
+  }
+}

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -17,5 +17,23 @@ export const quizSchema = z.object({
   complete: z.boolean().optional(),
 });
 
+export const quizBrandsSchema = z
+  .object({
+    quiz_id: z.string().uuid(),
+    favorite_brand_ids: z.array(z.string().uuid()).default([]),
+    custom_brand_names: z.array(z.string().min(2).max(50)).default([]),
+    auto_pick_brands: z.boolean().default(false),
+  })
+  .superRefine((val, ctx) => {
+    if (val.favorite_brand_ids.length + val.custom_brand_names.length > 3) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Too many brands",
+        path: ["favorite_brand_ids"],
+      });
+    }
+  });
+
 export type SubscribeInput = z.infer<typeof subscribeSchema>;
 export type QuizInput = z.infer<typeof quizSchema>;
+export type QuizBrandsInput = z.infer<typeof quizBrandsSchema>;

--- a/tests/brands.test.ts
+++ b/tests/brands.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from "vitest";
+import { GET as searchGET } from "../src/app/api/brands/search/route";
+import { GET as popularGET } from "../src/app/api/brands/popular/route";
+
+vi.mock("../src/lib/supabase-server", () => ({
+  getAdminClient: () => ({
+    rpc: (fn: string) => {
+      if (fn === "search_brands" || fn === "get_popular_brands") {
+        return Promise.resolve({
+          data: [
+            { id: "1", name: "Zara", tier: "mass", logo_url: "zara.png" },
+          ],
+          error: null,
+        });
+      }
+      return Promise.resolve({ data: [], error: null });
+    },
+  }),
+}));
+
+describe("GET /api/brands/search", () => {
+  it("returns results", async () => {
+    const res = await searchGET(
+      new Request("http://localhost/api/brands/search?q=zara")
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      items: [{ id: "1", name: "Zara", tier: "mass", logo_url: "zara.png" }],
+    });
+  });
+
+  it("requires q", async () => {
+    const res = await searchGET(
+      new Request("http://localhost/api/brands/search?q=z")
+    );
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("GET /api/brands/popular", () => {
+  it("returns popular brands", async () => {
+    const res = await popularGET(
+      new Request("http://localhost/api/brands/popular")
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      items: [{ id: "1", name: "Zara", tier: "mass", logo_url: "zara.png" }],
+    });
+  });
+});

--- a/tests/quizBrands.test.ts
+++ b/tests/quizBrands.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi } from "vitest";
+import { POST } from "../src/app/api/quiz/brands/route";
+import { GET } from "../src/app/api/quiz/[quizId]/brands/route";
+
+const mockFrom = (table: string) => {
+  if (table === "brands") {
+    return {
+      select: () => ({
+        in: () => ({
+          eq: () =>
+            Promise.resolve({
+              data: [{ id: "11111111-1111-1111-1111-111111111111" }],
+              error: null,
+            }),
+        }),
+      }),
+    };
+  }
+  if (table === "quiz_brand_selection") {
+    return {
+      delete: () => ({ eq: () => Promise.resolve({ error: null }) }),
+      insert: () => Promise.resolve({ error: null }),
+      select: () => ({
+        eq: () => ({
+          order: () =>
+            Promise.resolve({
+              data: [
+                {
+                  brand_id: "11111111-1111-1111-1111-111111111111",
+                  order_index: 0,
+                },
+              ],
+              error: null,
+            }),
+        }),
+      }),
+    };
+  }
+  if (table === "quiz_custom_brands") {
+    return {
+      delete: () => ({ eq: () => Promise.resolve({ error: null }) }),
+      insert: () => Promise.resolve({ error: null }),
+      select: () => ({ eq: () => Promise.resolve({ data: [{ name: "Local" }], error: null }) }),
+    };
+  }
+  if (table === "quiz_brand_flags") {
+    return {
+      upsert: () => Promise.resolve({ error: null }),
+      select: () => ({
+        eq: () => ({
+          maybeSingle: () => Promise.resolve({ data: { auto_pick: false }, error: null }),
+        }),
+      }),
+    };
+  }
+  return {} as unknown;
+};
+
+vi.mock("../src/lib/supabase-server", () => ({
+  getAdminClient: () => ({
+    from: mockFrom,
+  }),
+}));
+
+describe("POST /api/quiz/brands", () => {
+  it("saves selection", async () => {
+    const res = await POST(
+      new Request("http://localhost/api/quiz/brands", {
+        method: "POST",
+        body: JSON.stringify({
+          quiz_id: "123e4567-e89b-12d3-a456-426614174000",
+          favorite_brand_ids: ["11111111-1111-1111-1111-111111111111"],
+          custom_brand_names: ["Local"],
+          auto_pick_brands: false,
+        }),
+      })
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      saved: {
+        favorite_brand_ids: ["11111111-1111-1111-1111-111111111111"],
+        custom_brand_names: ["Local"],
+        auto_pick_brands: false,
+      },
+    });
+  });
+
+  it("rejects over limit", async () => {
+    const res = await POST(
+      new Request("http://localhost/api/quiz/brands", {
+        method: "POST",
+        body: JSON.stringify({
+          quiz_id: "123e4567-e89b-12d3-a456-426614174000",
+          favorite_brand_ids: [
+            "11111111-1111-1111-1111-111111111111",
+            "22222222-2222-2222-2222-222222222222",
+            "33333333-3333-3333-3333-333333333333",
+            "44444444-4444-4444-4444-444444444444",
+          ],
+        }),
+      })
+    );
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("GET /api/quiz/:id/brands", () => {
+  it("returns selection", async () => {
+    const res = await GET(
+      new Request(
+        "http://localhost/api/quiz/123e4567-e89b-12d3-a456-426614174000/brands"
+      ),
+      { params: { quizId: "123e4567-e89b-12d3-a456-426614174000" } }
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      favorite_brand_ids: ["11111111-1111-1111-1111-111111111111"],
+      custom_brand_names: ["Local"],
+      auto_pick_brands: false,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add SQL tables and helpers for brand search and selections
- implement brand search and popular endpoints with caching and rate limits
- support saving and retrieving quiz brand choices

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68acfabb3a2c832cb9954f8c4eeedbb8