### PR TITLE
feat: add brand selection API

### DIFF
--- a/src/app/api/brands/popular/route.ts
+++ b/src/app/api/brands/popular/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from "next/server";
+import { popularBrands, Tier } from "@/lib/brands";
+
+export function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const tierParam = searchParams.get("tier") as Tier | null;
+  const region = searchParams.get("region") || "ru";
+  const limit = parseInt(searchParams.get("limit") || "16", 10);
+  const items = popularBrands({ region, tier: tierParam || undefined, limit });
+  return NextResponse.json({ items });
+}

--- a/src/app/api/brands/search/route.ts
+++ b/src/app/api/brands/search/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from "next/server";
+import { searchBrands, Tier } from "@/lib/brands";
+
+const rateMap = new Map<string, { count: number; time: number }>();
+function rateLimit(ip: string, limit = 20, windowMs = 1_000) {
+  const now = Date.now();
+  const entry = rateMap.get(ip);
+  if (!entry || now - entry.time > windowMs) {
+    rateMap.set(ip, { count: 1, time: now });
+    return true;
+  }
+  if (entry.count >= limit) return false;
+  entry.count++;
+  return true;
+}
+
+export function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const q = searchParams.get("q");
+  if (!q || q.trim().length < 2)
+    return NextResponse.json({ message: "q too short" }, { status: 400 });
+
+  const tierParam = searchParams.get("tier") as Tier | null;
+  const region = searchParams.get("region") || "ru";
+  const limit = Math.min(parseInt(searchParams.get("limit") || "8", 10), 20);
+
+  const ip = req.headers.get("x-forwarded-for")?.split(",")[0] || "unknown";
+  if (!rateLimit(ip))
+    return NextResponse.json({ message: "Too many requests" }, { status: 429 });
+
+  const items = searchBrands({ q, region, tier: tierParam || undefined, limit });
+  return NextResponse.json({ items });
+}

--- a/src/app/api/quiz/[quizId]/brands/route.ts
+++ b/src/app/api/quiz/[quizId]/brands/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from "next/server";
+import { quizBrandSelections } from "@/lib/brands";
+
+export function GET(
+  req: Request,
+  context: { params: { quizId: string } }
+) {
+  const { quizId } = context.params;
+  const saved =
+    quizBrandSelections.get(quizId) || {
+      favorite_brand_ids: [],
+      custom_brand_names: [],
+      auto_pick_brands: false,
+    };
+  return NextResponse.json(saved);
+}

--- a/src/app/api/quiz/brands/route.ts
+++ b/src/app/api/quiz/brands/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from "next/server";
+import { brandSelectionSchema } from "@/lib/validators";
+import { BRANDS, quizBrandSelections } from "@/lib/brands";
+
+export async function POST(req: Request) {
+  try {
+    const json = await req.json();
+    const parsed = brandSelectionSchema.safeParse(json);
+    if (!parsed.success)
+      return NextResponse.json({ message: "Invalid payload" }, { status: 400 });
+
+    const { quiz_id, favorite_brand_ids, custom_brand_names, auto_pick_brands } =
+      parsed.data;
+
+    if (auto_pick_brands) {
+      const saved = {
+        favorite_brand_ids: [],
+        custom_brand_names: [],
+        auto_pick_brands: true,
+      };
+      quizBrandSelections.set(quiz_id, saved);
+      return NextResponse.json({ saved });
+    }
+
+    const activeIds = new Set(BRANDS.filter((b) => b.is_active).map((b) => b.id));
+    for (const id of favorite_brand_ids) {
+      if (!activeIds.has(id))
+        return NextResponse.json({ message: "Invalid brand id" }, { status: 400 });
+    }
+
+    const saved = {
+      favorite_brand_ids,
+      custom_brand_names,
+      auto_pick_brands: false,
+    };
+    quizBrandSelections.set(quiz_id, saved);
+    return NextResponse.json({ saved });
+  } catch (e) {
+    console.error(e);
+    return NextResponse.json({ message: "Internal error" }, { status: 500 });
+  }
+}

--- a/src/lib/brands.ts
+++ b/src/lib/brands.ts
@@ -1,0 +1,192 @@
+export type Tier = "mass" | "premium" | "luxury";
+
+export interface Brand {
+  id: string;
+  name: string;
+  slug: string;
+  tier: Tier;
+  logo_url: string;
+  aliases: string[];
+  is_active: boolean;
+  popularity: Record<string, number>;
+}
+
+export const BRANDS: Brand[] = [
+  {
+    id: "00000000-0000-0000-0000-000000000001",
+    name: "Zara",
+    slug: "zara",
+    tier: "mass",
+    logo_url: "https://cdn.example.com/zara.png",
+    aliases: ["zara", "зара"],
+    is_active: true,
+    popularity: { ru: 100 },
+  },
+  {
+    id: "00000000-0000-0000-0000-000000000002",
+    name: "COS",
+    slug: "cos",
+    tier: "premium",
+    logo_url: "https://cdn.example.com/cos.png",
+    aliases: ["cos", "косс"],
+    is_active: true,
+    popularity: { ru: 80 },
+  },
+];
+
+const searchCache = new Map<string, { expires: number; items: Brand[] }>();
+const popularCache = new Map<string, { expires: number; items: Brand[] }>();
+
+const tierWeight: Record<Tier, number> = { mass: 0, premium: 1, luxury: 2 };
+
+function transliterate(input: string): string {
+  const map: Record<string, string> = {
+    а: "a",
+    б: "b",
+    в: "v",
+    г: "g",
+    д: "d",
+    е: "e",
+    ё: "e",
+    ж: "zh",
+    з: "z",
+    и: "i",
+    й: "y",
+    к: "k",
+    л: "l",
+    м: "m",
+    н: "n",
+    о: "o",
+    п: "p",
+    р: "r",
+    с: "s",
+    т: "t",
+    у: "u",
+    ф: "f",
+    х: "h",
+    ц: "c",
+    ч: "ch",
+    ш: "sh",
+    щ: "sh",
+    ъ: "",
+    ы: "y",
+    ь: "",
+    э: "e",
+    ю: "yu",
+    я: "ya",
+  };
+  return input
+    .split("")
+    .map((c) => map[c] ?? c)
+    .join("");
+}
+
+function normalize(str: string): string {
+  return transliterate(
+    str
+      .toLowerCase()
+      .normalize("NFD")
+      .replace(/\p{Diacritic}/gu, "")
+      .replace(/[.,'"\-_\/]/g, "")
+  )
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function trigrams(s: string): Set<string> {
+  const padded = `  ${s} `;
+  const set = new Set<string>();
+  for (let i = 0; i < padded.length - 2; i++) {
+    set.add(padded.slice(i, i + 3));
+  }
+  return set;
+}
+
+function trigramSimilarity(a: string, b: string): number {
+  const aSet = trigrams(a);
+  const bSet = trigrams(b);
+  let intersection = 0;
+  for (const t of aSet) if (bSet.has(t)) intersection++;
+  const union = aSet.size + bSet.size - intersection;
+  return union === 0 ? 0 : intersection / union;
+}
+
+export function searchBrands({
+  q,
+  region,
+  tier,
+  limit,
+}: {
+  q: string;
+  region: string;
+  tier?: Tier;
+  limit: number;
+}): Brand[] {
+  const qNorm = normalize(q);
+  const cacheKey = `${region}:${tier ?? "all"}:${qNorm}`;
+  const now = Date.now();
+  const cached = searchCache.get(cacheKey);
+  if (cached && cached.expires > now) return cached.items;
+
+  let candidates = BRANDS.filter((b) => b.is_active);
+  if (tier) candidates = candidates.filter((b) => b.tier === tier);
+  const scored: { brand: Brand; score: number }[] = [];
+  for (const brand of candidates) {
+    let bestScore = 0;
+    const names = [brand.name, ...brand.aliases];
+    for (const n of names) {
+      const nNorm = normalize(n);
+      if (nNorm === qNorm) {
+        bestScore = Math.max(bestScore, 100);
+      } else if (nNorm.startsWith(qNorm)) {
+        bestScore = Math.max(bestScore, 60);
+      } else {
+        const sim = trigramSimilarity(nNorm, qNorm);
+        if (sim >= 0.35) {
+          bestScore = Math.max(bestScore, 40 * sim);
+        }
+      }
+    }
+    if (bestScore > 0) {
+      bestScore += (brand.popularity[region] ?? 0) * 2;
+      bestScore += tierWeight[brand.tier];
+      scored.push({ brand, score: bestScore });
+    }
+  }
+  scored.sort((a, b) => b.score - a.score);
+  const items = scored.slice(0, limit).map((s) => s.brand);
+  searchCache.set(cacheKey, { expires: now + 600_000, items });
+  return items;
+}
+
+export function popularBrands({
+  region,
+  tier,
+  limit,
+}: {
+  region: string;
+  tier?: Tier;
+  limit: number;
+}): Brand[] {
+  const cacheKey = `${region}:${tier ?? "all"}:${limit}`;
+  const now = Date.now();
+  const cached = popularCache.get(cacheKey);
+  if (cached && cached.expires > now) return cached.items;
+
+  let items = BRANDS.filter((b) => b.is_active);
+  if (tier) items = items.filter((b) => b.tier === tier);
+  items = items.sort(
+    (a, b) => (b.popularity[region] ?? 0) - (a.popularity[region] ?? 0)
+  );
+  items = items.slice(0, limit);
+  popularCache.set(cacheKey, { expires: now + 3_600_000, items });
+  return items;
+}
+
+export interface QuizBrandSelection {
+  favorite_brand_ids: string[];
+  custom_brand_names: string[];
+  auto_pick_brands: boolean;
+}
+
+export const quizBrandSelections = new Map<string, QuizBrandSelection>();

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -19,3 +19,17 @@ export const quizSchema = z.object({
 
 export type SubscribeInput = z.infer<typeof subscribeSchema>;
 export type QuizInput = z.infer<typeof quizSchema>;
+
+export const brandSelectionSchema = z
+  .object({
+    quiz_id: z.string().uuid(),
+    favorite_brand_ids: z.array(z.string().uuid()).max(3).default([]),
+    custom_brand_names: z.array(z.string().min(2).max(50)).max(3).default([]),
+    auto_pick_brands: z.boolean().default(false),
+  })
+  .refine(
+    (data) => data.favorite_brand_ids.length + data.custom_brand_names.length <= 3,
+    { message: "Too many brands" }
+  );
+
+export type BrandSelectionInput = z.infer<typeof brandSelectionSchema>;

--- a/tests/brands.test.ts
+++ b/tests/brands.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { GET as search } from "../src/app/api/brands/search/route";
+import { POST as saveBrands } from "../src/app/api/quiz/brands/route";
+import { GET as getBrands } from "../src/app/api/quiz/[quizId]/brands/route";
+
+const ZARA_ID = "00000000-0000-0000-0000-000000000001";
+const COS_ID = "00000000-0000-0000-0000-000000000002";
+
+describe("Brand search", () => {
+  it("finds by transliteration and alias", async () => {
+    let res = await search(
+      new Request("http://localhost/api/brands/search?q=zarra&region=ru")
+    );
+    expect(res.status).toBe(200);
+    let json = await res.json();
+    expect(json.items[0].name).toBe("Zara");
+
+    res = await search(
+      new Request("http://localhost/api/brands/search?q=косс&region=ru")
+    );
+    json = await res.json();
+    expect(json.items[0].name).toBe("COS");
+  });
+});
+
+describe("Quiz brand selection", () => {
+  it("validates limit and retrieves selection", async () => {
+    const quiz_id = "123e4567-e89b-12d3-a456-426614174001";
+    let res = await saveBrands(
+      new Request("http://localhost/api/quiz/brands", {
+        method: "POST",
+        body: JSON.stringify({
+          quiz_id,
+          favorite_brand_ids: [ZARA_ID, COS_ID],
+          custom_brand_names: ["BrandX", "BrandY"],
+        }),
+      })
+    );
+    expect(res.status).toBe(400);
+
+    res = await saveBrands(
+      new Request("http://localhost/api/quiz/brands", {
+        method: "POST",
+        body: JSON.stringify({
+          quiz_id,
+          favorite_brand_ids: [ZARA_ID],
+          custom_brand_names: ["Local Atelier"],
+        }),
+      })
+    );
+    expect(res.status).toBe(200);
+
+    const getRes = await getBrands(
+      new Request(`http://localhost/api/quiz/${quiz_id}/brands`),
+      { params: { quizId: quiz_id } }
+    );
+    const saved = await getRes.json();
+    expect(saved.favorite_brand_ids).toEqual([ZARA_ID]);
+    expect(saved.custom_brand_names).toEqual(["Local Atelier"]);
+  });
+});


### PR DESCRIPTION
## Summary
- add static brand dataset with fuzzy search and popularity helpers
- expose /api/brands/search and /api/brands/popular endpoints
- support saving and fetching quiz brand selections

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68acfabb3a2c832cb9954f8c4eeedbb8