### PR TITLE
feat: add use case step

### DIFF
--- a/src/components/Quiz.tsx
+++ b/src/components/Quiz.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import UseCaseStep from "./quiz/UseCaseStep";
 import StyleStep from "./quiz/StyleStep";
 import ColorDislikeStep from "./quiz/ColorDislikeStep";
 import PhotoStep from "./quiz/PhotoStep";
@@ -11,8 +12,11 @@ interface QuizProps {
 }
 
 // initial data structure
+import type { SelectedUseCase } from "@/types/usecase";
+
 interface QuizData {
-  goal: string;
+  usecases: SelectedUseCase[];
+  auto_pick_usecases: boolean;
   budget: number;
   city: string;
   photo?: File | null;
@@ -37,7 +41,7 @@ interface QuizData {
 
 export function Quiz({ onClose }: QuizProps) {
   const stepOrder = [
-    "goal",
+    "usecases",
     "budget",
     "city",
     "photo",
@@ -59,7 +63,8 @@ export function Quiz({ onClose }: QuizProps) {
   const stepId: StepId = stepOrder[step];
   const [submitted, setSubmitted] = useState(false);
   const [data, setData] = useState<QuizData>({
-    goal: "office_casual",
+    usecases: [],
+    auto_pick_usecases: false,
     budget: 25000,
     city: "Москва",
     photo: null,
@@ -116,33 +121,14 @@ export function Quiz({ onClose }: QuizProps) {
 
   const renderStep = () => {
     switch (stepId) {
-      case "goal":
+      case "usecases":
         return (
-          <div>
-            <h2 className="mb-6 text-xl font-semibold">Под что собираем капсулу?</h2>
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-              {[
-                { value: "office_casual", label: "Офис" },
-                { value: "date", label: "Свидание" },
-                { value: "weekend", label: "Выходные" },
-                { value: "season_update", label: "Сезон" },
-              ].map((g) => (
-                <label
-                  key={g.value}
-                  className="flex cursor-pointer items-center gap-2 rounded-lg border p-3 hover:bg-gray-50"
-                >
-                  <input
-                    type="radio"
-                    name="goal"
-                    value={g.value}
-                    checked={data.goal === g.value}
-                    onChange={(e) => update({ goal: e.target.value })}
-                  />
-                  {g.label}
-                </label>
-              ))}
-            </div>
-          </div>
+          <UseCaseStep
+            selected={data.usecases}
+            autoPick={data.auto_pick_usecases}
+            onChange={(v) => update({ usecases: v })}
+            onAutoPickChange={(v) => update({ auto_pick_usecases: v })}
+          />
         );
       case "budget":
         return (
@@ -318,7 +304,7 @@ export function Quiz({ onClose }: QuizProps) {
           <StyleStep
             selected={data.style}
             onChange={(style) => update({ style })}
-            goal={data.goal}
+            useCase={data.usecases[0]?.id}
           />
         );
       case "color_dislike":
@@ -475,6 +461,13 @@ export function Quiz({ onClose }: QuizProps) {
             <button
               className="button primary"
               onClick={() => {
+                if (stepId === "usecases") {
+                  sendEvent("quiz_next_click", {
+                    step: 1,
+                    auto_pick: data.auto_pick_usecases,
+                    usecases: data.usecases,
+                  });
+                }
                 if (stepId === "color_dislike") {
                   sendEvent("quiz_next_click", {
                     step: 10,

--- a/src/components/quiz/StyleStep.tsx
+++ b/src/components/quiz/StyleStep.tsx
@@ -4,7 +4,7 @@ import clsx from "clsx";
 export interface StyleStepProps {
   selected: string[];
   onChange: (styles: string[]) => void;
-  goal: string;
+  useCase?: string;
 }
 
 interface StyleOption {
@@ -44,13 +44,15 @@ const OPTIONS: StyleOption[] = [
 ];
 
 const AUTO_PICK: Record<string, string[]> = {
+  office: ["casual", "classic"],
   office_casual: ["casual", "classic"],
   date: ["casual", "classic"],
   weekend: ["casual", "sport"],
+  season: ["minimal", "sport"],
   season_update: ["minimal", "sport"],
 };
 
-export default function StyleStep({ selected, onChange, goal }: StyleStepProps) {
+export default function StyleStep({ selected, onChange, useCase }: StyleStepProps) {
   const [auto, setAuto] = useState(false);
   const [showExamples, setShowExamples] = useState(false);
   const [limitHit, setLimitHit] = useState(false);
@@ -58,10 +60,10 @@ export default function StyleStep({ selected, onChange, goal }: StyleStepProps) 
 
   useEffect(() => {
     if (auto) {
-      const defaults = AUTO_PICK[goal] || [];
+      const defaults = AUTO_PICK[useCase || ""] || [];
       onChange(defaults.slice(0, 2));
     }
-  }, [auto, goal, onChange]);
+  }, [auto, useCase, onChange]);
 
   useEffect(() => {
     if (limitHit) {
@@ -112,7 +114,7 @@ export default function StyleStep({ selected, onChange, goal }: StyleStepProps) 
     const next = !auto;
     setAuto(next);
     if (next) {
-      const defaults = AUTO_PICK[goal] || [];
+      const defaults = AUTO_PICK[useCase || ""] || [];
       onChange(defaults.slice(0, 2));
     } else {
       onChange([]);

--- a/src/components/quiz/UseCaseStep.tsx
+++ b/src/components/quiz/UseCaseStep.tsx
@@ -1,0 +1,205 @@
+import { useEffect, useState } from 'react';
+import clsx from 'clsx';
+import type { SelectedUseCase, UseCaseId } from '@/types/usecase';
+import { USE_CASES, POPULAR_USE_CASES } from './usecases.config';
+
+interface UseCaseStepProps {
+  selected: SelectedUseCase[];
+  autoPick: boolean;
+  onChange: (selected: SelectedUseCase[]) => void;
+  onAutoPickChange: (v: boolean) => void;
+}
+
+export default function UseCaseStep({
+  selected,
+  autoPick,
+  onChange,
+  onAutoPickChange,
+}: UseCaseStepProps) {
+  const [showMore, setShowMore] = useState(false);
+  const [limitHit, setLimitHit] = useState(false);
+  const [toast, setToast] = useState<string | null>(null);
+
+  useEffect(() => {
+    USE_CASES.forEach((opt) => sendEvent('usecase_card_view', { id: opt.id }));
+  }, []);
+
+  const toggle = (id: UseCaseId) => {
+    if (autoPick) return;
+    const exists = selected.find((u) => u.id === id);
+    if (exists) {
+      const next = selected.filter((u) => u.id !== id).map((u, i) => ({ ...u, priority: (i + 1) as 1 | 2 | 3 }));
+      onChange(next);
+      sendEvent('usecase_deselect', { id, total: next.length });
+      return;
+    }
+    if (selected.length >= 3) {
+      setToast('Не более трёх сценариев');
+      setLimitHit(true);
+      setTimeout(() => setLimitHit(false), 600);
+      setTimeout(() => setToast(null), 2000);
+      sendEvent('usecase_limit_hit');
+      return;
+    }
+    const next = [...selected, { id, priority: (selected.length + 1) as 1 | 2 | 3 }];
+    onChange(next);
+    sendEvent('usecase_select', { id, total: next.length });
+  };
+
+  const handleAuto = () => {
+    const next = !autoPick;
+    onAutoPickChange(next);
+    if (next) onChange([]);
+    sendEvent('usecase_autopick_toggle', { value: next });
+  };
+
+  const setProp = (id: UseCaseId, key: string, value: string) => {
+    const next = selected.map((u) =>
+      u.id === id ? { ...u, props: { ...u.props, [key]: value } } : u
+    );
+    onChange(next);
+    sendEvent('usecase_subprop_set', { id, key, value });
+  };
+
+  const move = (from: number, to: number) => {
+    if (from === to) return;
+    const next = [...selected];
+    const [item] = next.splice(from, 1);
+    next.splice(to, 0, item);
+    const reordered = next.map((u, i) => ({ ...u, priority: (i + 1) as 1 | 2 | 3 }));
+    onChange(reordered);
+    sendEvent('usecase_reorder', { from: from + 1, to: to + 1 });
+  };
+
+  const handleDrag = {
+    onDragStart: (index: number) => (e: React.DragEvent) => {
+      e.dataTransfer.setData('text/plain', String(index));
+    },
+    onDragOver: (index: number) => (e: React.DragEvent) => {
+      e.preventDefault();
+      const from = Number(e.dataTransfer.getData('text/plain'));
+      if (from !== index) move(from, index);
+    },
+  };
+
+  const renderSubprops = (id: UseCaseId) => {
+    const uc = USE_CASES.find((u) => u.id === id);
+    if (!uc?.subprops) return null;
+    return (
+      <div className="mt-2 flex flex-wrap gap-2">
+        {uc.subprops.map((sp) => (
+          <select
+            key={sp.key}
+            value={selected.find((u) => u.id === id)?.props?.[sp.key] || ''}
+            onChange={(e) => setProp(id, sp.key, e.target.value)}
+            className="rounded border px-2 py-1 text-sm"
+          >
+            <option value="" disabled>
+              {sp.key}
+            </option>
+            {sp.options.map((opt) => (
+              <option key={opt} value={opt}>
+                {opt}
+              </option>
+            ))}
+          </select>
+        ))}
+      </div>
+    );
+  };
+
+  const allOptions = showMore ? USE_CASES : POPULAR_USE_CASES;
+
+  return (
+    <div>
+      <div className="mb-4">
+        <h2 className="mb-1 text-xl font-semibold">Под что собираем капсулу?</h2>
+        <p className="text-sm text-gray-600">
+          Можно выбрать до трёх. Перетащите, чтобы расставить по приоритету
+        </p>
+        {toast && (
+          <div className="mt-2 rounded bg-red-50 px-3 py-2 text-sm text-red-600">
+            {toast}
+          </div>
+        )}
+        {selected.length > 0 && (
+          <div className="mt-3 flex gap-2">
+            {selected.map((uc, idx) => (
+              <div
+                key={uc.id}
+                draggable
+                onDragStart={handleDrag.onDragStart(idx)}
+                onDragOver={handleDrag.onDragOver(idx)}
+                className="flex items-center gap-1 rounded border bg-white px-2 py-1 text-sm shadow"
+              >
+                <span className="font-semibold">{idx + 1}</span>
+                <span>{USE_CASES.find((u) => u.id === uc.id)?.title}</span>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+      <div
+        role="listbox"
+        aria-multiselectable="true"
+        className={clsx(
+          'grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-4',
+          limitHit && 'animate-shake'
+        )}
+      >
+        {allOptions.map((opt) => {
+          const isSelected = selected.some((u) => u.id === opt.id);
+          const blocked = selected.length >= 3 && !isSelected;
+          const disabled = autoPick || blocked;
+          return (
+            <button
+              key={opt.id}
+              type="button"
+              role="option"
+              aria-selected={isSelected}
+              aria-disabled={disabled}
+              onClick={() => toggle(opt.id)}
+              className={clsx(
+                'relative flex flex-col items-center rounded-2xl border border-[#E8E9ED] bg-[#F7F7F8] p-4 shadow-sm transition',
+                disabled && 'opacity-50',
+                isSelected && 'ring-2 ring-[var(--brand-500)]'
+              )}
+            >
+              <img src={opt.icon} alt="" className="mb-2 h-12 w-12" />
+              <span className="text-sm">{opt.title}</span>
+              {isSelected && (
+                <span className="absolute right-2 top-2 rounded bg-[var(--brand-500)] px-1 text-xs text-white">
+                  {selected.find((u) => u.id === opt.id)?.priority}
+                </span>
+              )}
+            </button>
+          );
+        })}
+      </div>
+      <div className="mt-4 flex flex-wrap gap-3">
+        <button
+          type="button"
+          onClick={handleAuto}
+          className={clsx(
+            'rounded-full border px-3 py-1 text-sm',
+            autoPick ? 'border-[var(--brand-500)] text-[var(--brand-500)]' : 'border-gray-300'
+          )}
+        >
+          Не знаю — выбрать за меня
+        </button>
+        {!showMore && (
+          <button
+            type="button"
+            onClick={() => setShowMore(true)}
+            className="text-sm text-[var(--brand-500)]"
+          >
+            Показать больше сценариев
+          </button>
+        )}
+      </div>
+      {selected.map((uc) => (
+        <div key={uc.id}>{renderSubprops(uc.id)}</div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/quiz/usecases.config.ts
+++ b/src/components/quiz/usecases.config.ts
@@ -1,0 +1,100 @@
+import type { UseCase } from '@/types/usecase';
+
+export const USE_CASES: UseCase[] = [
+  {
+    id: 'office',
+    title: 'Офис',
+    icon: '/icons/usecases/office.svg',
+    popular: true,
+    subprops: [
+      {
+        key: 'dress_code',
+        type: 'enum',
+        options: ['business_formal', 'smart_casual', 'free'],
+      },
+    ],
+  },
+  {
+    id: 'everyday',
+    title: 'Каждый день',
+    icon: '/icons/usecases/everyday.svg',
+    popular: true,
+    subprops: [
+      {
+        key: 'formality',
+        type: 'enum',
+        options: ['relaxed', 'smart_casual'],
+      },
+    ],
+  },
+  {
+    id: 'date',
+    title: 'Свидание/вечер',
+    icon: '/icons/usecases/date.svg',
+    popular: true,
+    subprops: [
+      { key: 'place', type: 'enum', options: ['restaurant', 'walk', 'cinema'] },
+    ],
+  },
+  {
+    id: 'weekend',
+    title: 'Выходные/кэжуал',
+    icon: '/icons/usecases/weekend.svg',
+    popular: true,
+    subprops: [
+      {
+        key: 'formality',
+        type: 'enum',
+        options: ['relaxed', 'smart_casual'],
+      },
+    ],
+  },
+  {
+    id: 'travel',
+    title: 'Путешествие',
+    icon: '/icons/usecases/travel.svg',
+    popular: true,
+    subprops: [
+      { key: 'climate', type: 'enum', options: ['hot', 'mild', 'cold'] },
+      { key: 'trip_duration', type: 'enum', options: ['2-3d', '1w', '2w+'] },
+    ],
+  },
+  {
+    id: 'season',
+    title: 'Сезонная капсула',
+    icon: '/icons/usecases/season.svg',
+    popular: true,
+    subprops: [
+      {
+        key: 'season',
+        type: 'enum',
+        options: ['ss', 'aw', 'spring', 'summer', 'autumn', 'winter'],
+      },
+    ],
+  },
+  {
+    id: 'event',
+    title: 'Событие',
+    icon: '/icons/usecases/event.svg',
+    popular: true,
+    subprops: [
+      {
+        key: 'event_type',
+        type: 'enum',
+        options: ['wedding', 'grad', 'cocktail', 'corporate', 'other'],
+      },
+    ],
+  },
+  { id: 'business_trip', title: 'Бизнес-поездка', icon: '/icons/usecases/business_trip.svg' },
+  { id: 'wedding_guest', title: 'Свадьба', icon: '/icons/usecases/wedding_guest.svg' },
+  { id: 'party', title: 'Вечеринка/коктейль', icon: '/icons/usecases/party.svg' },
+  { id: 'campus', title: 'Университет/кампус', icon: '/icons/usecases/campus.svg' },
+  { id: 'athleisure', title: 'Спорт-шик', icon: '/icons/usecases/athleisure.svg' },
+  { id: 'wardrobe_refresh', title: 'Обновление базы', icon: '/icons/usecases/wardrobe_refresh.svg' },
+  { id: 'photo_shoot', title: 'Фотосессия', icon: '/icons/usecases/photo_shoot.svg' },
+  { id: 'streetwear', title: 'Уличный стиль', icon: '/icons/usecases/streetwear.svg' },
+  { id: 'vacation_beach', title: 'Отпуск-море', icon: '/icons/usecases/vacation_beach.svg' },
+  { id: 'outdoor', title: 'Outdoor/погода', icon: '/icons/usecases/outdoor.svg' },
+];
+
+export const POPULAR_USE_CASES = USE_CASES.filter((u) => u.popular);

--- a/src/lib/usecaseValidation.ts
+++ b/src/lib/usecaseValidation.ts
@@ -1,0 +1,21 @@
+import type { SelectedUseCase } from '@/types/usecase';
+import { USE_CASES } from '@/components/quiz/usecases.config';
+
+export function validateUseCases(items: SelectedUseCase[]): boolean {
+  if (items.length > 3) return false;
+  const priorities = new Set<number>();
+  for (const uc of items) {
+    if (priorities.has(uc.priority)) return false;
+    priorities.add(uc.priority);
+    const cfg = USE_CASES.find((c) => c.id === uc.id);
+    if (!cfg) return false;
+    if (uc.props) {
+      for (const [k, v] of Object.entries(uc.props)) {
+        const sp = cfg.subprops?.find((s) => s.key === k);
+        if (!sp) return false;
+        if (!sp.options.includes(v)) return false;
+      }
+    }
+  }
+  return true;
+}

--- a/src/types/usecase.ts
+++ b/src/types/usecase.ts
@@ -1,0 +1,45 @@
+export type UseCaseId =
+  | 'office'
+  | 'everyday'
+  | 'date'
+  | 'weekend'
+  | 'travel'
+  | 'season'
+  | 'event'
+  | 'business_trip'
+  | 'wedding_guest'
+  | 'party'
+  | 'campus'
+  | 'athleisure'
+  | 'wardrobe_refresh'
+  | 'photo_shoot'
+  | 'streetwear'
+  | 'vacation_beach'
+  | 'outdoor';
+
+export interface UseCaseSubpropOption {
+  key:
+    | 'dress_code'
+    | 'climate'
+    | 'trip_duration'
+    | 'season'
+    | 'event_type'
+    | 'formality'
+    | 'place';
+  type: 'enum';
+  options: string[];
+}
+
+export interface UseCase {
+  id: UseCaseId;
+  title: string;
+  icon: string;
+  popular?: boolean;
+  subprops?: UseCaseSubpropOption[];
+}
+
+export interface SelectedUseCase {
+  id: UseCaseId;
+  priority: 1 | 2 | 3;
+  props?: Record<string, string>;
+}

--- a/tests/usecase.test.ts
+++ b/tests/usecase.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { validateUseCases } from '../src/lib/usecaseValidation';
+
+describe('validateUseCases', () => {
+  it('validates correct selection', () => {
+    const res = validateUseCases([
+      { id: 'office', priority: 1, props: { dress_code: 'smart_casual' } },
+      { id: 'season', priority: 2, props: { season: 'aw' } },
+    ]);
+    expect(res).toBe(true);
+  });
+
+  it('rejects more than three', () => {
+    const res = validateUseCases([
+      { id: 'office', priority: 1 },
+      { id: 'season', priority: 2 },
+      { id: 'event', priority: 3 },
+      { id: 'travel', priority: 1 },
+    ]);
+    expect(res).toBe(false);
+  });
+
+  it('rejects duplicate priority', () => {
+    const res = validateUseCases([
+      { id: 'office', priority: 1 },
+      { id: 'season', priority: 1 },
+    ]);
+    expect(res).toBe(false);
+  });
+
+  it('rejects invalid prop', () => {
+    const res = validateUseCases([
+      { id: 'office', priority: 1, props: { dress_code: 'invalid' } },
+    ]);
+    expect(res).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add multi-select use case step with drag-and-drop priority and autopick toggle
- link primary use case to style step auto suggestions
- validate selected use cases and cover with unit tests

## Testing
- `pnpm test`
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68acfae633cc832c97cf8c560d13de10