### PR TITLE
feat: add use case selection step

### DIFF
--- a/src/components/Quiz.tsx
+++ b/src/components/Quiz.tsx
@@ -5,6 +5,8 @@ import StyleStep from "./quiz/StyleStep";
 import ColorDislikeStep from "./quiz/ColorDislikeStep";
 import PhotoStep from "./quiz/PhotoStep";
 import FavoriteBrandsStep, { type Brand } from "./quiz/FavoriteBrandsStep";
+import UseCaseStep from "./quiz/UseCaseStep";
+import type { SelectedUseCase } from "@/lib/usecases";
 
 interface QuizProps {
   onClose: () => void;
@@ -12,7 +14,8 @@ interface QuizProps {
 
 // initial data structure
 interface QuizData {
-  goal: string;
+  usecases: SelectedUseCase[];
+  auto_pick_usecases: boolean;
   budget: number;
   city: string;
   photo?: File | null;
@@ -37,7 +40,7 @@ interface QuizData {
 
 export function Quiz({ onClose }: QuizProps) {
   const stepOrder = [
-    "goal",
+    "usecases",
     "budget",
     "city",
     "photo",
@@ -59,7 +62,8 @@ export function Quiz({ onClose }: QuizProps) {
   const stepId: StepId = stepOrder[step];
   const [submitted, setSubmitted] = useState(false);
   const [data, setData] = useState<QuizData>({
-    goal: "office_casual",
+    usecases: [],
+    auto_pick_usecases: false,
     budget: 25000,
     city: "Москва",
     photo: null,
@@ -116,33 +120,14 @@ export function Quiz({ onClose }: QuizProps) {
 
   const renderStep = () => {
     switch (stepId) {
-      case "goal":
+      case "usecases":
         return (
-          <div>
-            <h2 className="mb-6 text-xl font-semibold">Под что собираем капсулу?</h2>
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-              {[
-                { value: "office_casual", label: "Офис" },
-                { value: "date", label: "Свидание" },
-                { value: "weekend", label: "Выходные" },
-                { value: "season_update", label: "Сезон" },
-              ].map((g) => (
-                <label
-                  key={g.value}
-                  className="flex cursor-pointer items-center gap-2 rounded-lg border p-3 hover:bg-gray-50"
-                >
-                  <input
-                    type="radio"
-                    name="goal"
-                    value={g.value}
-                    checked={data.goal === g.value}
-                    onChange={(e) => update({ goal: e.target.value })}
-                  />
-                  {g.label}
-                </label>
-              ))}
-            </div>
-          </div>
+          <UseCaseStep
+            selected={data.usecases}
+            onChange={(usecases) => update({ usecases })}
+            auto={data.auto_pick_usecases}
+            onAutoChange={(v) => update({ auto_pick_usecases: v })}
+          />
         );
       case "budget":
         return (
@@ -318,7 +303,7 @@ export function Quiz({ onClose }: QuizProps) {
           <StyleStep
             selected={data.style}
             onChange={(style) => update({ style })}
-            goal={data.goal}
+            primaryUseCase={data.usecases[0]?.id || ""}
           />
         );
       case "color_dislike":

--- a/src/components/quiz/StyleStep.tsx
+++ b/src/components/quiz/StyleStep.tsx
@@ -4,7 +4,8 @@ import clsx from "clsx";
 export interface StyleStepProps {
   selected: string[];
   onChange: (styles: string[]) => void;
-  goal: string;
+  /** primary use case id to derive suggestions */
+  primaryUseCase: string;
 }
 
 interface StyleOption {
@@ -44,13 +45,13 @@ const OPTIONS: StyleOption[] = [
 ];
 
 const AUTO_PICK: Record<string, string[]> = {
-  office_casual: ["casual", "classic"],
+  office: ["casual", "classic"],
   date: ["casual", "classic"],
   weekend: ["casual", "sport"],
-  season_update: ["minimal", "sport"],
+  season: ["minimal", "sport"],
 };
 
-export default function StyleStep({ selected, onChange, goal }: StyleStepProps) {
+export default function StyleStep({ selected, onChange, primaryUseCase }: StyleStepProps) {
   const [auto, setAuto] = useState(false);
   const [showExamples, setShowExamples] = useState(false);
   const [limitHit, setLimitHit] = useState(false);
@@ -58,10 +59,10 @@ export default function StyleStep({ selected, onChange, goal }: StyleStepProps) 
 
   useEffect(() => {
     if (auto) {
-      const defaults = AUTO_PICK[goal] || [];
+      const defaults = AUTO_PICK[primaryUseCase] || [];
       onChange(defaults.slice(0, 2));
     }
-  }, [auto, goal, onChange]);
+  }, [auto, primaryUseCase, onChange]);
 
   useEffect(() => {
     if (limitHit) {
@@ -112,7 +113,7 @@ export default function StyleStep({ selected, onChange, goal }: StyleStepProps) 
     const next = !auto;
     setAuto(next);
     if (next) {
-      const defaults = AUTO_PICK[goal] || [];
+      const defaults = AUTO_PICK[primaryUseCase] || [];
       onChange(defaults.slice(0, 2));
     } else {
       onChange([]);

--- a/src/components/quiz/UseCaseStep.tsx
+++ b/src/components/quiz/UseCaseStep.tsx
@@ -1,0 +1,222 @@
+import { useEffect, useState } from "react";
+import clsx from "clsx";
+import { USECASES, type SelectedUseCase, SUBPROP_LABELS } from "@/lib/usecases";
+
+interface UseCaseStepProps {
+  selected: SelectedUseCase[];
+  onChange: (value: SelectedUseCase[]) => void;
+  auto: boolean;
+  onAutoChange: (v: boolean) => void;
+}
+
+export default function UseCaseStep({ selected, onChange, auto, onAutoChange }: UseCaseStepProps) {
+  const [showMore, setShowMore] = useState(false);
+  const [toast, setToast] = useState<string | null>(null);
+  const [limitHit, setLimitHit] = useState(false);
+
+  useEffect(() => {
+    USECASES.forEach((u) => sendEvent("usecase_card_view", { id: u.id }));
+  }, []);
+
+  useEffect(() => {
+    if (limitHit) {
+      const t = setTimeout(() => setLimitHit(false), 600);
+      const to = setTimeout(() => setToast(null), 2000);
+      return () => {
+        clearTimeout(t);
+        clearTimeout(to);
+      };
+    }
+  }, [limitHit]);
+
+  const toggle = (id: SelectedUseCase["id"]) => {
+    if (auto) return;
+    const exists = selected.find((u) => u.id === id);
+    if (exists) {
+      const next = selected.filter((u) => u.id !== id).map((u, i) => ({ ...u, priority: (i + 1) as 1 | 2 | 3 }));
+      onChange(next);
+      sendEvent("usecase_deselect", { id, total: next.length });
+      return;
+    }
+    if (selected.length >= 3) {
+      setToast("Не более трёх сценариев");
+      setLimitHit(true);
+      sendEvent("usecase_limit_hit");
+      return;
+    }
+    const next = [...selected, { id, priority: (selected.length + 1) as 1 | 2 | 3 }];
+    onChange(next);
+    sendEvent("usecase_select", { id, total: next.length });
+  };
+
+  const handleReorder = (from: number, to: number) => {
+    if (to < 0 || to >= selected.length) return;
+    const next = [...selected];
+    const [item] = next.splice(from, 1);
+    next.splice(to, 0, item);
+    onChange(next.map((u, i) => ({ ...u, priority: (i + 1) as 1 | 2 | 3 })));
+    sendEvent("usecase_reorder", { from: from + 1, to: to + 1 });
+  };
+
+  const handlePropChange = (id: SelectedUseCase["id"], key: string, value: string) => {
+    const next = selected.map((u) =>
+      u.id === id ? { ...u, props: { ...u.props, [key]: value } } : u
+    );
+    onChange(next);
+    sendEvent("usecase_subprop_set", { id, key, value });
+  };
+
+  const handleAuto = () => {
+    const next = !auto;
+    onAutoChange(next);
+    if (next) onChange([]);
+    sendEvent("usecase_autopick_toggle", { value: next });
+  };
+
+  const top = USECASES.filter((u) => u.popular);
+  const extra = USECASES.filter((u) => !u.popular);
+  const options = showMore ? [...top, ...extra] : top;
+  const count = selected.length;
+  const counterClass = clsx("text-sm", limitHit ? "text-red-500 animate-shake" : "text-gray-500");
+
+  return (
+    <div>
+      <div className="mb-4">
+        <div className="text-xs text-gray-500">Шаг 1/14</div>
+        <div className="flex items-baseline justify-between">
+          <h2 className="text-2xl font-bold">Под что собираем капсулу?</h2>
+          <span className={counterClass}>{limitHit ? "4/3" : `${count}/3`}</span>
+        </div>
+        <p className="mt-1 text-sm text-gray-500">
+          Можно выбрать до трёх. Перетащите выбранные, чтобы задать приоритет
+        </p>
+        {toast && <div className="mt-2 rounded bg-red-50 px-3 py-2 text-sm text-red-600">{toast}</div>}
+      </div>
+
+      {count > 0 && (
+        <ul className="mb-4 flex gap-2" aria-label="Выбранные сценарии">
+          {selected.map((s, idx) => {
+            const uc = USECASES.find((u) => u.id === s.id);
+            if (!uc) return null;
+            return (
+              <li key={s.id} className="flex items-center gap-1 rounded-full bg-[var(--brand-50)] px-2 py-1 text-sm">
+                <span>
+                  {idx + 1}. {uc.title}
+                </span>
+                <div className="flex flex-col">
+                  <button
+                    aria-label="Вверх"
+                    disabled={idx === 0}
+                    onClick={() => handleReorder(idx, idx - 1)}
+                  >
+                    ▲
+                  </button>
+                  <button
+                    aria-label="Вниз"
+                    disabled={idx === selected.length - 1}
+                    onClick={() => handleReorder(idx, idx + 1)}
+                  >
+                    ▼
+                  </button>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      <div
+        role="listbox"
+        aria-multiselectable="true"
+        className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4"
+      >
+        {options.map((opt) => {
+          const isSelected = selected.some((s) => s.id === opt.id);
+          const blocked = count >= 3 && !isSelected;
+          return (
+            <button
+              key={opt.id}
+              type="button"
+              role="option"
+              aria-selected={isSelected}
+              aria-disabled={auto || blocked}
+              onClick={() => toggle(opt.id)}
+              className={clsx(
+                "relative flex flex-col items-center rounded-2xl border p-4 text-center shadow-[0_6px_20px_rgba(0,0,0,0.06)] transition",
+                !auto && !blocked &&
+                  "hover:-translate-y-0.5 hover:border-[var(--brand-500)] focus-visible:border-[var(--brand-500)]",
+                (auto || blocked) && "cursor-not-allowed opacity-40",
+                isSelected && "border-2 border-[var(--brand-500)]",
+                "focus:outline-none"
+              )}
+            >
+              <img src={opt.icon} alt="" className="mb-2 h-12 w-12" />
+              <div>{opt.title}</div>
+              {isSelected && (
+                <span className="absolute right-2 top-2 flex h-6 w-6 items-center justify-center rounded-full bg-[var(--brand-500)] text-white">
+                  {selected.findIndex((s) => s.id === opt.id) + 1}
+                </span>
+              )}
+            </button>
+          );
+        })}
+      </div>
+
+      {selected.map((s) => {
+        const uc = USECASES.find((u) => u.id === s.id);
+        if (!uc?.subprops) return null;
+        return (
+          <div key={s.id} className="mt-4">
+            <h3 className="mb-2 text-sm font-medium">{uc.title}</h3>
+            <div className="flex flex-wrap gap-2">
+              {uc.subprops.map((sp) => (
+                <label key={sp.key} className="flex flex-col text-sm">
+                  <span className="mb-1">{sp.key}</span>
+                  <select
+                    className="input h-9"
+                    value={s.props?.[sp.key] ?? ""}
+                    onChange={(e) => handlePropChange(s.id, sp.key, e.target.value)}
+                  >
+                    <option value="">—</option>
+                    {sp.options.map((o) => (
+                      <option key={o} value={o}>
+                        {SUBPROP_LABELS[sp.key]?.[o] || o}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              ))}
+            </div>
+          </div>
+        );
+      })}
+
+      <div className="mt-6 flex flex-wrap gap-3">
+        <button
+          type="button"
+          onClick={handleAuto}
+          className="rounded-full border px-3 py-1 text-sm"
+        >
+          {auto ? "Сбросить автоподбор" : "Не знаю — выбрать за меня"}
+        </button>
+        {!showMore && (
+          <button
+            type="button"
+            onClick={() => setShowMore(true)}
+            className="rounded-full border px-3 py-1 text-sm"
+          >
+            Показать больше сценариев
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function sendEvent(event: string, props?: Record<string, unknown>) {
+  if (typeof window !== "undefined") {
+    const win = window as { plausible?: (e: string, o?: Record<string, unknown>) => void };
+    win.plausible?.(event, props);
+  }
+}
+

--- a/src/lib/usecases.ts
+++ b/src/lib/usecases.ts
@@ -1,0 +1,168 @@
+export type UseCaseId =
+  | 'office'
+  | 'everyday'
+  | 'date'
+  | 'weekend'
+  | 'travel'
+  | 'season'
+  | 'event'
+  | 'business_trip'
+  | 'wedding_guest'
+  | 'party'
+  | 'campus'
+  | 'athleisure'
+  | 'wardrobe_refresh'
+  | 'photo_shoot'
+  | 'streetwear'
+  | 'vacation_beach'
+  | 'outdoor';
+
+export type UseCaseSubprop =
+  | { key: 'dress_code'; type: 'enum'; options: ('business_formal'|'smart_casual'|'free')[] }
+  | { key: 'climate'; type: 'enum'; options: ('hot'|'mild'|'cold')[] }
+  | { key: 'trip_duration'; type: 'enum'; options: ('2-3d'|'1w'|'2w+')[] }
+  | { key: 'season'; type: 'enum'; options: ('ss'|'aw'|'spring'|'summer'|'autumn'|'winter')[] }
+  | { key: 'event_type'; type: 'enum'; options: ('wedding'|'grad'|'cocktail'|'corporate'|'other')[] }
+  | { key: 'formality'; type: 'enum'; options: ('relaxed'|'smart_casual')[] }
+  | { key: 'place'; type: 'enum'; options: ('restaurant'|'walk'|'cinema')[] }
+  | { key: 'date_known'; type: 'enum'; options: ('yes'|'no')[] };
+
+export interface UseCase {
+  id: UseCaseId;
+  title: string;
+  icon: string;
+  popular?: boolean;
+  subprops?: UseCaseSubprop[];
+}
+
+export interface SelectedUseCase {
+  id: UseCaseId;
+  priority: 1|2|3;
+  props?: Record<string,string>;
+}
+
+export const USECASES: UseCase[] = [
+  {
+    id: 'office',
+    title: 'Офис',
+    icon: '/icons/usecases/office.svg',
+    popular: true,
+    subprops: [
+      { key: 'dress_code', type: 'enum', options: ['business_formal','smart_casual','free'] }
+    ],
+  },
+  {
+    id: 'everyday',
+    title: 'Каждый день',
+    icon: '/icons/usecases/everyday.svg',
+    popular: true,
+    subprops: [
+      { key: 'formality', type: 'enum', options: ['relaxed','smart_casual'] }
+    ],
+  },
+  {
+    id: 'date',
+    title: 'Свидание/вечер',
+    icon: '/icons/usecases/date.svg',
+    popular: true,
+    subprops: [
+      { key: 'place', type: 'enum', options: ['restaurant','walk','cinema'] }
+    ],
+  },
+  {
+    id: 'weekend',
+    title: 'Выходные/кэжуал',
+    icon: '/icons/usecases/weekend.svg',
+    popular: true,
+    subprops: [
+      { key: 'formality', type: 'enum', options: ['relaxed','smart_casual'] }
+    ],
+  },
+  {
+    id: 'travel',
+    title: 'Путешествие',
+    icon: '/icons/usecases/travel.svg',
+    popular: true,
+    subprops: [
+      { key: 'climate', type: 'enum', options: ['hot','mild','cold'] },
+      { key: 'trip_duration', type: 'enum', options: ['2-3d','1w','2w+'] }
+    ],
+  },
+  {
+    id: 'season',
+    title: 'Сезонная капсула',
+    icon: '/icons/usecases/season.svg',
+    popular: true,
+    subprops: [
+      { key: 'season', type: 'enum', options: ['ss','aw','spring','summer','autumn','winter'] }
+    ],
+  },
+  {
+    id: 'event',
+    title: 'Событие',
+    icon: '/icons/usecases/event.svg',
+    popular: true,
+    subprops: [
+      { key: 'event_type', type: 'enum', options: ['wedding','grad','cocktail','corporate','other'] },
+      { key: 'date_known', type: 'enum', options: ['yes','no'] }
+    ],
+  },
+  // additional
+  { id: 'business_trip', title: 'Бизнес-поездка', icon: '/icons/usecases/business_trip.svg' },
+  { id: 'wedding_guest', title: 'Свадьба', icon: '/icons/usecases/wedding_guest.svg' },
+  { id: 'party', title: 'Вечеринка/коктейль', icon: '/icons/usecases/party.svg' },
+  { id: 'campus', title: 'Университет/кампус', icon: '/icons/usecases/campus.svg' },
+  { id: 'athleisure', title: 'Спорт-шик', icon: '/icons/usecases/athleisure.svg' },
+  { id: 'wardrobe_refresh', title: 'Обновление базы', icon: '/icons/usecases/wardrobe_refresh.svg' },
+  { id: 'photo_shoot', title: 'Фотосессия', icon: '/icons/usecases/photo_shoot.svg' },
+  { id: 'streetwear', title: 'Уличный стиль', icon: '/icons/usecases/streetwear.svg' },
+  { id: 'vacation_beach', title: 'Отпуск-море', icon: '/icons/usecases/vacation_beach.svg' },
+  { id: 'outdoor', title: 'Outdoor/погода', icon: '/icons/usecases/outdoor.svg' },
+];
+
+export const SUBPROP_LABELS: Record<string, Record<string, string>> = {
+  dress_code: {
+    business_formal: 'Business formal',
+    smart_casual: 'Smart casual',
+    free: 'Свободный',
+  },
+  climate: {
+    hot: 'Жарко',
+    mild: 'Умеренно',
+    cold: 'Холодно',
+  },
+  trip_duration: {
+    '2-3d': '2-3 дня',
+    '1w': '1 неделя',
+    '2w+': '2+ недели',
+  },
+  season: {
+    ss: 'SS',
+    aw: 'AW',
+    spring: 'Весна',
+    summer: 'Лето',
+    autumn: 'Осень',
+    winter: 'Зима',
+  },
+  event_type: {
+    wedding: 'Свадьба',
+    grad: 'Выпускной',
+    cocktail: 'Коктейль',
+    corporate: 'Корпоратив',
+    other: 'Другое',
+  },
+  formality: {
+    relaxed: 'Спокойно',
+    smart_casual: 'Smart casual',
+  },
+  place: {
+    restaurant: 'Ресторан',
+    walk: 'Прогулка',
+    cinema: 'Кино',
+  },
+  date_known: {
+    yes: 'Дата известна',
+    no: 'Дата не известна',
+  },
+};
+


### PR DESCRIPTION
## Summary
- replace goal radio buttons with new multi-select UseCase step
- load use case metadata from shared config and expose sub-parameters
- adapt style step to derive auto-pick from primary use case

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68acfae633cc832c97cf8c560d13de10