### PR TITLE
feat: add use case selection to quiz

### DIFF
--- a/src/components/Quiz.tsx
+++ b/src/components/Quiz.tsx
@@ -5,6 +5,8 @@ import StyleStep from "./quiz/StyleStep";
 import ColorDislikeStep from "./quiz/ColorDislikeStep";
 import PhotoStep from "./quiz/PhotoStep";
 import FavoriteBrandsStep, { type Brand } from "./quiz/FavoriteBrandsStep";
+import UseCaseStep from "./quiz/UseCaseStep";
+import { type SelectedUseCase } from "./quiz/usecases.config";
 
 interface QuizProps {
   onClose: () => void;
@@ -12,7 +14,8 @@ interface QuizProps {
 
 // initial data structure
 interface QuizData {
-  goal: string;
+  usecases: SelectedUseCase[];
+  auto_pick_usecases: boolean;
   budget: number;
   city: string;
   photo?: File | null;
@@ -37,7 +40,7 @@ interface QuizData {
 
 export function Quiz({ onClose }: QuizProps) {
   const stepOrder = [
-    "goal",
+    "usecases",
     "budget",
     "city",
     "photo",
@@ -59,7 +62,8 @@ export function Quiz({ onClose }: QuizProps) {
   const stepId: StepId = stepOrder[step];
   const [submitted, setSubmitted] = useState(false);
   const [data, setData] = useState<QuizData>({
-    goal: "office_casual",
+    usecases: [],
+    auto_pick_usecases: false,
     budget: 25000,
     city: "Москва",
     photo: null,
@@ -116,33 +120,13 @@ export function Quiz({ onClose }: QuizProps) {
 
   const renderStep = () => {
     switch (stepId) {
-      case "goal":
+      case "usecases":
         return (
-          <div>
-            <h2 className="mb-6 text-xl font-semibold">Под что собираем капсулу?</h2>
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-              {[
-                { value: "office_casual", label: "Офис" },
-                { value: "date", label: "Свидание" },
-                { value: "weekend", label: "Выходные" },
-                { value: "season_update", label: "Сезон" },
-              ].map((g) => (
-                <label
-                  key={g.value}
-                  className="flex cursor-pointer items-center gap-2 rounded-lg border p-3 hover:bg-gray-50"
-                >
-                  <input
-                    type="radio"
-                    name="goal"
-                    value={g.value}
-                    checked={data.goal === g.value}
-                    onChange={(e) => update({ goal: e.target.value })}
-                  />
-                  {g.label}
-                </label>
-              ))}
-            </div>
-          </div>
+          <UseCaseStep
+            selected={data.usecases}
+            autoPick={data.auto_pick_usecases}
+            onChange={(usecases, auto) => update({ usecases, auto_pick_usecases: auto })}
+          />
         );
       case "budget":
         return (
@@ -318,7 +302,7 @@ export function Quiz({ onClose }: QuizProps) {
           <StyleStep
             selected={data.style}
             onChange={(style) => update({ style })}
-            goal={data.goal}
+            useCase={data.usecases[0]?.id}
           />
         );
       case "color_dislike":
@@ -475,6 +459,13 @@ export function Quiz({ onClose }: QuizProps) {
             <button
               className="button primary"
               onClick={() => {
+                if (stepId === "usecases") {
+                  sendEvent("quiz_next_click", {
+                    step: 1,
+                    auto_pick: data.auto_pick_usecases,
+                    usecases: data.usecases,
+                  });
+                }
                 if (stepId === "color_dislike") {
                   sendEvent("quiz_next_click", {
                     step: 10,

--- a/src/components/quiz/StyleStep.tsx
+++ b/src/components/quiz/StyleStep.tsx
@@ -4,7 +4,7 @@ import clsx from "clsx";
 export interface StyleStepProps {
   selected: string[];
   onChange: (styles: string[]) => void;
-  goal: string;
+  useCase?: string;
 }
 
 interface StyleOption {
@@ -44,13 +44,13 @@ const OPTIONS: StyleOption[] = [
 ];
 
 const AUTO_PICK: Record<string, string[]> = {
-  office_casual: ["casual", "classic"],
+  office: ["casual", "classic"],
   date: ["casual", "classic"],
   weekend: ["casual", "sport"],
-  season_update: ["minimal", "sport"],
+  season: ["minimal", "sport"],
 };
 
-export default function StyleStep({ selected, onChange, goal }: StyleStepProps) {
+export default function StyleStep({ selected, onChange, useCase }: StyleStepProps) {
   const [auto, setAuto] = useState(false);
   const [showExamples, setShowExamples] = useState(false);
   const [limitHit, setLimitHit] = useState(false);
@@ -58,10 +58,10 @@ export default function StyleStep({ selected, onChange, goal }: StyleStepProps) 
 
   useEffect(() => {
     if (auto) {
-      const defaults = AUTO_PICK[goal] || [];
+      const defaults = AUTO_PICK[useCase || ""] || [];
       onChange(defaults.slice(0, 2));
     }
-  }, [auto, goal, onChange]);
+  }, [auto, useCase, onChange]);
 
   useEffect(() => {
     if (limitHit) {
@@ -112,7 +112,7 @@ export default function StyleStep({ selected, onChange, goal }: StyleStepProps) 
     const next = !auto;
     setAuto(next);
     if (next) {
-      const defaults = AUTO_PICK[goal] || [];
+      const defaults = AUTO_PICK[useCase || ""] || [];
       onChange(defaults.slice(0, 2));
     } else {
       onChange([]);

--- a/src/components/quiz/UseCaseStep.tsx
+++ b/src/components/quiz/UseCaseStep.tsx
@@ -1,0 +1,187 @@
+import { useState } from 'react';
+import clsx from 'clsx';
+import { USE_CASES, type SelectedUseCase, type UseCaseId } from './usecases.config';
+
+export interface UseCaseStepProps {
+  selected: SelectedUseCase[];
+  autoPick: boolean;
+  onChange: (selected: SelectedUseCase[], autoPick: boolean) => void;
+}
+
+export default function UseCaseStep({ selected, autoPick, onChange }: UseCaseStepProps) {
+  const [showMore, setShowMore] = useState(false);
+  const [toast, setToast] = useState<string | null>(null);
+
+  const visible = USE_CASES.filter((u) => showMore || u.popular);
+
+  const toggle = (id: UseCaseId) => {
+    if (autoPick) return;
+    const exists = selected.find((s) => s.id === id);
+    if (exists) {
+      const next = selected
+        .filter((s) => s.id !== id)
+        .map((s, i) => ({ ...s, priority: (i + 1) as 1 | 2 | 3 }));
+      onChange(next, false);
+      sendEvent('usecase_deselect', { id, total: next.length });
+      return;
+    }
+    if (selected.length >= 3) {
+      setToast('Не более трёх сценариев');
+      sendEvent('usecase_limit_hit');
+      setTimeout(() => setToast(null), 2000);
+      return;
+    }
+    const next = [
+      ...selected,
+      { id, priority: (selected.length + 1) as 1 | 2 | 3 },
+    ];
+    onChange(next, false);
+    sendEvent('usecase_select', { id, total: next.length });
+  };
+
+  const handleAuto = () => {
+    const next = !autoPick;
+    onChange([], next);
+    sendEvent('usecase_autopick_toggle', { value: next });
+  };
+
+  const move = (from: number, to: number) => {
+    const arr = [...selected];
+    const item = arr.splice(from, 1)[0];
+    arr.splice(to, 0, item);
+    const next = arr.map((s, i) => ({ ...s, priority: (i + 1) as 1 | 2 | 3 }));
+    onChange(next, false);
+    sendEvent('usecase_reorder', { from: from + 1, to: to + 1 });
+  };
+
+  const handleProp = (id: UseCaseId, key: string, value: string) => {
+    const next = selected.map((s) =>
+      s.id === id ? { ...s, props: { ...(s.props || {}), [key]: value } } : s
+    );
+    onChange(next, false);
+    sendEvent('usecase_subprop_set', { id, key, value });
+  };
+
+  return (
+    <div>
+      <h2 className="text-xl font-semibold mb-2">Под что собираем капсулу?</h2>
+      <p className="mb-4 text-sm text-gray-600">Можно выбрать до трёх. Перетащите выбранные, чтобы задать приоритет</p>
+
+      {selected.length > 0 && (
+        <div className="mb-4 flex flex-wrap gap-2">
+          {selected.map((s, i) => {
+            const uc = USE_CASES.find((u) => u.id === s.id)!;
+            return (
+              <div key={s.id} className="flex items-center gap-1 rounded-full bg-gray-100 px-3 py-1 text-sm">
+                <span>{i + 1}. {uc.title}</span>
+                <div className="flex flex-col leading-none">
+                  <button
+                    aria-label="Вверх"
+                    disabled={i === 0}
+                    onClick={() => move(i, i - 1)}
+                  >
+                    ▲
+                  </button>
+                  <button
+                    aria-label="Вниз"
+                    disabled={i === selected.length - 1}
+                    onClick={() => move(i, i + 1)}
+                  >
+                    ▼
+                  </button>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      <div
+        className="grid grid-cols-2 sm:grid-cols-4 gap-4"
+        role="listbox"
+        aria-multiselectable="true"
+      >
+        {visible.map((u) => {
+          const isSelected = selected.some((s) => s.id === u.id);
+          const order = selected.findIndex((s) => s.id === u.id) + 1;
+          return (
+            <div key={u.id} className="space-y-2">
+              <button
+                type="button"
+                role="option"
+                aria-selected={isSelected}
+                onClick={() => toggle(u.id)}
+                disabled={autoPick}
+                className={clsx(
+                  'relative w-full rounded-2xl border p-4 text-center transition',
+                  isSelected ? 'border-[var(--brand-500)] shadow' : 'border-gray-200 hover:border-gray-300',
+                  autoPick && 'cursor-not-allowed opacity-50'
+                )}
+              >
+                <div className="mx-auto mb-2 h-12 w-12">
+                  <img src={u.icon} alt="" className="h-full w-full object-contain" />
+                </div>
+                <div>{u.title}</div>
+                {isSelected && (
+                  <span className="absolute right-2 top-2 rounded-full bg-[var(--brand-500)] px-2 py-1 text-xs text-white">
+                    {order}
+                  </span>
+                )}
+              </button>
+              {isSelected && u.subprops && (
+                <div className="flex flex-wrap gap-2">
+                  {u.subprops.map((sp) => (
+                    <select
+                      key={sp.key}
+                      className="rounded border p-1 text-sm"
+                      value={selected.find((s) => s.id === u.id)?.props?.[sp.key] || ''}
+                      onChange={(e) => handleProp(u.id, sp.key, e.target.value)}
+                    >
+                      <option value="">—</option>
+                      {sp.options.map((opt) => (
+                        <option key={opt} value={opt}>
+                          {opt}
+                        </option>
+                      ))}
+                    </select>
+                  ))}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      {toast && <div className="mt-4 text-sm text-red-600">{toast}</div>}
+
+      <div className="mt-6 flex flex-wrap items-center gap-3">
+        <button
+          type="button"
+          onClick={handleAuto}
+          className={clsx(
+            'rounded-full border px-4 py-1 text-sm',
+            autoPick ? 'border-[var(--brand-500)] bg-[var(--brand-50)] text-[var(--brand-700)]' : 'border-gray-300 text-gray-600'
+          )}
+        >
+          Не знаю — выбрать за меня
+        </button>
+        {!showMore && (
+          <button
+            type="button"
+            className="text-sm text-[var(--brand-600)] underline"
+            onClick={() => setShowMore(true)}
+          >
+            Показать больше сценариев
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function sendEvent(event: string, props?: Record<string, unknown>) {
+  if (typeof window !== 'undefined') {
+    const win = window as { plausible?: (e: string, o?: Record<string, unknown>) => void };
+    win.plausible?.(event, props);
+  }
+}

--- a/src/components/quiz/usecases.config.ts
+++ b/src/components/quiz/usecases.config.ts
@@ -1,0 +1,120 @@
+export type UseCaseId =
+  | 'office'
+  | 'everyday'
+  | 'date'
+  | 'weekend'
+  | 'travel'
+  | 'season'
+  | 'event'
+  | 'business_trip'
+  | 'wedding_guest'
+  | 'party'
+  | 'campus'
+  | 'athleisure'
+  | 'wardrobe_refresh'
+  | 'photo_shoot'
+  | 'streetwear'
+  | 'vacation_beach'
+  | 'outdoor';
+
+export type UseCaseSubprop =
+  | { key: 'dress_code'; type: 'enum'; options: ('business_formal'|'smart_casual'|'free')[] }
+  | { key: 'climate'; type: 'enum'; options: ('hot'|'mild'|'cold')[] }
+  | { key: 'trip_duration'; type: 'enum'; options: ('2-3d'|'1w'|'2w+')[] }
+  | { key: 'season'; type: 'enum'; options: ('ss'|'aw'|'spring'|'summer'|'autumn'|'winter')[] }
+  | { key: 'event_type'; type: 'enum'; options: ('wedding'|'grad'|'cocktail'|'corporate'|'other')[] }
+  | { key: 'date_known'; type: 'enum'; options: ('yes'|'no')[] }
+  | { key: 'formality'; type: 'enum'; options: ('relaxed'|'smart_casual')[] }
+  | { key: 'place'; type: 'enum'; options: ('restaurant'|'walk'|'cinema')[] };
+
+export interface UseCase {
+  id: UseCaseId;
+  title: string;
+  icon: string;
+  popular?: boolean;
+  subprops?: UseCaseSubprop[];
+}
+
+export type SelectedUseCase = {
+  id: UseCaseId;
+  priority: 1 | 2 | 3;
+  props?: Record<string, string>;
+};
+
+export const USE_CASES: UseCase[] = [
+  {
+    id: 'office',
+    title: 'Офис',
+    icon: '/icons/usecases/office.svg',
+    popular: true,
+    subprops: [
+      { key: 'dress_code', type: 'enum', options: ['business_formal', 'smart_casual', 'free'] },
+    ],
+  },
+  {
+    id: 'everyday',
+    title: 'Каждый день',
+    icon: '/icons/usecases/everyday.svg',
+    popular: true,
+    subprops: [
+      { key: 'formality', type: 'enum', options: ['relaxed', 'smart_casual'] },
+    ],
+  },
+  {
+    id: 'date',
+    title: 'Свидание/вечер',
+    icon: '/icons/usecases/date.svg',
+    popular: true,
+    subprops: [
+      { key: 'place', type: 'enum', options: ['restaurant', 'walk', 'cinema'] },
+    ],
+  },
+  {
+    id: 'weekend',
+    title: 'Выходные/кэжуал',
+    icon: '/icons/usecases/weekend.svg',
+    popular: true,
+    subprops: [
+      { key: 'formality', type: 'enum', options: ['relaxed', 'smart_casual'] },
+    ],
+  },
+  {
+    id: 'travel',
+    title: 'Путешествие',
+    icon: '/icons/usecases/travel.svg',
+    popular: true,
+    subprops: [
+      { key: 'climate', type: 'enum', options: ['hot', 'mild', 'cold'] },
+      { key: 'trip_duration', type: 'enum', options: ['2-3d', '1w', '2w+'] },
+    ],
+  },
+  {
+    id: 'season',
+    title: 'Сезонная капсула',
+    icon: '/icons/usecases/season.svg',
+    popular: true,
+    subprops: [
+      { key: 'season', type: 'enum', options: ['ss', 'aw', 'spring', 'summer', 'autumn', 'winter'] },
+    ],
+  },
+  {
+    id: 'event',
+    title: 'Событие',
+    icon: '/icons/usecases/event.svg',
+    popular: true,
+    subprops: [
+      { key: 'event_type', type: 'enum', options: ['wedding', 'grad', 'cocktail', 'corporate', 'other'] },
+      { key: 'date_known', type: 'enum', options: ['yes', 'no'] },
+    ],
+  },
+  { id: 'business_trip', title: 'Бизнес-поездка', icon: '/icons/usecases/business_trip.svg' },
+  { id: 'wedding_guest', title: 'Свадьба', icon: '/icons/usecases/wedding_guest.svg' },
+  { id: 'party', title: 'Вечеринка/коктейль', icon: '/icons/usecases/party.svg' },
+  { id: 'campus', title: 'Университет/кампус', icon: '/icons/usecases/campus.svg' },
+  { id: 'athleisure', title: 'Спорт-шик/athleisure', icon: '/icons/usecases/athleisure.svg' },
+  { id: 'wardrobe_refresh', title: 'Обновление базы', icon: '/icons/usecases/wardrobe_refresh.svg' },
+  { id: 'photo_shoot', title: 'Фотосессия', icon: '/icons/usecases/photo_shoot.svg' },
+  { id: 'streetwear', title: 'Уличный стиль', icon: '/icons/usecases/streetwear.svg' },
+  { id: 'vacation_beach', title: 'Отпуск-море', icon: '/icons/usecases/vacation_beach.svg' },
+  { id: 'outdoor', title: 'Outdoor/погода', icon: '/icons/usecases/outdoor.svg' },
+];


### PR DESCRIPTION
## Summary
- replace single goal radio with multi-select use case cards
- allow automatic or manual prioritization of up to three scenarios with sub-settings
- seed style suggestions from the primary use case

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68acfae633cc832c97cf8c560d13de10