### PR TITLE
feat: add use case selection step

### DIFF
--- a/public/icons/usecases/placeholder.svg
+++ b/public/icons/usecases/placeholder.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
+</svg>

--- a/src/components/Quiz.tsx
+++ b/src/components/Quiz.tsx
@@ -5,6 +5,8 @@ import StyleStep from "./quiz/StyleStep";
 import ColorDislikeStep from "./quiz/ColorDislikeStep";
 import PhotoStep from "./quiz/PhotoStep";
 import FavoriteBrandsStep, { type Brand } from "./quiz/FavoriteBrandsStep";
+import UseCaseStep from "./quiz/UseCaseStep";
+import type { SelectedUseCase } from "@/types/usecases";
 
 interface QuizProps {
   onClose: () => void;
@@ -12,7 +14,8 @@ interface QuizProps {
 
 // initial data structure
 interface QuizData {
-  goal: string;
+  usecases: SelectedUseCase[];
+  auto_pick_usecases: boolean;
   budget: number;
   city: string;
   photo?: File | null;
@@ -37,7 +40,7 @@ interface QuizData {
 
 export function Quiz({ onClose }: QuizProps) {
   const stepOrder = [
-    "goal",
+    "usecases",
     "budget",
     "city",
     "photo",
@@ -59,7 +62,8 @@ export function Quiz({ onClose }: QuizProps) {
   const stepId: StepId = stepOrder[step];
   const [submitted, setSubmitted] = useState(false);
   const [data, setData] = useState<QuizData>({
-    goal: "office_casual",
+    usecases: [],
+    auto_pick_usecases: false,
     budget: 25000,
     city: "Москва",
     photo: null,
@@ -116,33 +120,14 @@ export function Quiz({ onClose }: QuizProps) {
 
   const renderStep = () => {
     switch (stepId) {
-      case "goal":
+      case "usecases":
         return (
-          <div>
-            <h2 className="mb-6 text-xl font-semibold">Под что собираем капсулу?</h2>
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-              {[
-                { value: "office_casual", label: "Офис" },
-                { value: "date", label: "Свидание" },
-                { value: "weekend", label: "Выходные" },
-                { value: "season_update", label: "Сезон" },
-              ].map((g) => (
-                <label
-                  key={g.value}
-                  className="flex cursor-pointer items-center gap-2 rounded-lg border p-3 hover:bg-gray-50"
-                >
-                  <input
-                    type="radio"
-                    name="goal"
-                    value={g.value}
-                    checked={data.goal === g.value}
-                    onChange={(e) => update({ goal: e.target.value })}
-                  />
-                  {g.label}
-                </label>
-              ))}
-            </div>
-          </div>
+          <UseCaseStep
+            selected={data.usecases}
+            autoPick={data.auto_pick_usecases}
+            onChange={(v) => update({ usecases: v })}
+            onAutoPickChange={(v) => update({ auto_pick_usecases: v })}
+          />
         );
       case "budget":
         return (
@@ -318,7 +303,7 @@ export function Quiz({ onClose }: QuizProps) {
           <StyleStep
             selected={data.style}
             onChange={(style) => update({ style })}
-            goal={data.goal}
+            goal={data.usecases[0]?.id || ""}
           />
         );
       case "color_dislike":
@@ -475,7 +460,13 @@ export function Quiz({ onClose }: QuizProps) {
             <button
               className="button primary"
               onClick={() => {
-                if (stepId === "color_dislike") {
+                if (stepId === "usecases") {
+                  sendEvent("quiz_next_click", {
+                    step: 1,
+                    auto_pick: data.auto_pick_usecases,
+                    usecases: data.usecases,
+                  });
+                } else if (stepId === "color_dislike") {
                   sendEvent("quiz_next_click", {
                     step: 10,
                     dislikedColors: data.color_dislike,

--- a/src/components/quiz/StyleStep.tsx
+++ b/src/components/quiz/StyleStep.tsx
@@ -44,10 +44,10 @@ const OPTIONS: StyleOption[] = [
 ];
 
 const AUTO_PICK: Record<string, string[]> = {
-  office_casual: ["casual", "classic"],
+  office: ["casual", "classic"],
   date: ["casual", "classic"],
   weekend: ["casual", "sport"],
-  season_update: ["minimal", "sport"],
+  season: ["minimal", "sport"],
 };
 
 export default function StyleStep({ selected, onChange, goal }: StyleStepProps) {

--- a/src/components/quiz/UseCaseStep.tsx
+++ b/src/components/quiz/UseCaseStep.tsx
@@ -1,0 +1,263 @@
+import { useEffect, useState } from "react";
+import clsx from "clsx";
+import type { SelectedUseCase, UseCase } from "@/types/usecases";
+import { USE_CASES } from "./usecases.config";
+
+interface UseCaseStepProps {
+  selected: SelectedUseCase[];
+  autoPick: boolean;
+  onChange: (usecases: SelectedUseCase[]) => void;
+  onAutoPickChange: (v: boolean) => void;
+}
+
+const SUBPROP_LABELS: Record<string, string> = {
+  dress_code: "Дресс-код",
+  climate: "Климат",
+  trip_duration: "Длительность",
+  season: "Сезон",
+  event_type: "Тип события",
+  formality: "Формальность",
+  place: "Место",
+};
+
+const OPTION_LABELS: Record<string, Record<string, string>> = {
+  dress_code: {
+    business_formal: "Строгий",
+    smart_casual: "Smart casual",
+    free: "Свободный",
+  },
+  climate: { hot: "Жарко", mild: "Умеренно", cold: "Холодно" },
+  trip_duration: { "2-3d": "2-3 дня", "1w": "1 неделя", "2w+": "2+ недели" },
+  season: { ss: "SS", aw: "AW", spring: "Весна", summer: "Лето", autumn: "Осень", winter: "Зима" },
+  event_type: {
+    wedding: "Свадьба",
+    grad: "Выпускной",
+    cocktail: "Коктейль",
+    corporate: "Корпоратив",
+    other: "Другое",
+  },
+  formality: { relaxed: "Спокойно", smart_casual: "Smart casual" },
+  place: { restaurant: "Ресторан", walk: "Прогулка", cinema: "Кино" },
+};
+
+export default function UseCaseStep({ selected, autoPick, onChange, onAutoPickChange }: UseCaseStepProps) {
+  const [showMore, setShowMore] = useState(false);
+  const [toast, setToast] = useState<string | null>(null);
+  const [dragIndex, setDragIndex] = useState<number | null>(null);
+  const limitHit = toast !== null;
+
+  useEffect(() => {
+    USE_CASES.forEach((c) => sendEvent("usecase_card_view", { id: c.id }));
+  }, []);
+
+  const visibleCases = showMore ? USE_CASES : USE_CASES.filter((c) => c.popular);
+
+  const toggle = (id: UseCase["id"]) => {
+    if (autoPick) {
+      const agree = confirm("Отключить автоматический выбор и выбрать вручную?");
+      if (!agree) return;
+      onAutoPickChange(false);
+      onChange([]);
+    }
+    const exists = selected.find((u) => u.id === id);
+    if (exists) {
+      const next = selected
+        .filter((u) => u.id !== id)
+        .map((u, i) => ({ ...u, priority: (i + 1) as 1 | 2 | 3 }));
+      onChange(next);
+      sendEvent("usecase_deselect", { id, total: next.length });
+      return;
+    }
+    if (selected.length >= 3) {
+      setToast("Не более трёх сценариев");
+      setTimeout(() => setToast(null), 2000);
+      sendEvent("usecase_limit_hit");
+      return;
+    }
+    const next = [...selected, { id, priority: (selected.length + 1) as 1 | 2 | 3 }];
+    onChange(next);
+    sendEvent("usecase_select", { id, total: next.length });
+  };
+
+  const reorder = (from: number, to: number) => {
+    if (to < 0 || to >= selected.length) return;
+    const arr = [...selected];
+    const [item] = arr.splice(from, 1);
+    arr.splice(to, 0, item);
+    const next = arr.map((u, i) => ({ ...u, priority: (i + 1) as 1 | 2 | 3 }));
+    onChange(next);
+    sendEvent("usecase_reorder", { from: from + 1, to: to + 1 });
+  };
+
+  const handleDragOver = (e: React.DragEvent, idx: number) => {
+    e.preventDefault();
+    if (dragIndex === null || dragIndex === idx) return;
+    reorder(dragIndex, idx);
+    setDragIndex(idx);
+  };
+
+  const handleDragStart = (idx: number) => setDragIndex(idx);
+  const handleDragEnd = () => setDragIndex(null);
+
+  const handleAuto = () => {
+    const next = !autoPick;
+    onAutoPickChange(next);
+    if (next) onChange([]);
+    sendEvent("usecase_autopick_toggle", { value: next });
+  };
+
+  const updateProp = (id: UseCase["id"], key: string, value: string) => {
+    const next = selected.map((u) =>
+      u.id === id ? { ...u, props: { ...u.props, [key]: value } } : u
+    );
+    onChange(next);
+    sendEvent("usecase_subprop_set", { id, key, value });
+  };
+
+  return (
+    <div>
+      <h2 className="mb-1 text-xl font-semibold">Под что собираем капсулу?</h2>
+      <p className="mb-4 text-sm text-gray-500">
+        Можно выбрать до трёх. Перетащите выбранные, чтобы задать приоритет
+      </p>
+      {selected.length > 0 && (
+        <div className="mb-4 flex gap-2 overflow-x-auto">
+          {selected.map((u, idx) => {
+            const conf = USE_CASES.find((c) => c.id === u.id)!;
+            return (
+              <div
+                key={u.id}
+                className="flex items-center gap-1 rounded-full border px-3 py-1 text-sm"
+                draggable
+                onDragStart={() => handleDragStart(idx)}
+                onDragOver={(e) => handleDragOver(e, idx)}
+                onDragEnd={handleDragEnd}
+              >
+                <span className="font-medium">{idx + 1}.</span>
+                <span>{conf.title}</span>
+                <div className="ml-1 flex flex-col">
+                  <button
+                    aria-label="Вверх"
+                    onClick={() => reorder(idx, idx - 1)}
+                    disabled={idx === 0}
+                    className="leading-none"
+                  >
+                    ▲
+                  </button>
+                  <button
+                    aria-label="Вниз"
+                    onClick={() => reorder(idx, idx + 1)}
+                    disabled={idx === selected.length - 1}
+                    className="leading-none"
+                  >
+                    ▼
+                  </button>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+      {toast && (
+        <div className="mb-2 rounded bg-red-50 px-3 py-2 text-sm text-red-600">
+          {toast}
+        </div>
+      )}
+      <div
+        role="listbox"
+        aria-multiselectable="true"
+        className={clsx(
+          "grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4",
+          limitHit && "animate-shake"
+        )}
+      >
+        {visibleCases.map((uc) => {
+          const isSelected = selected.some((u) => u.id === uc.id);
+          const disabled = autoPick || (!isSelected && selected.length >= 3);
+          const index = selected.findIndex((u) => u.id === uc.id);
+          return (
+            <button
+              key={uc.id}
+              type="button"
+              role="option"
+              aria-selected={isSelected}
+              aria-disabled={disabled}
+              disabled={disabled}
+              onClick={() => toggle(uc.id)}
+              className={clsx(
+                "relative flex flex-col items-center rounded-2xl border border-[#E8E9ED] bg-[#F7F7F8] p-4 text-center shadow transition",
+                !disabled &&
+                  "hover:-translate-y-0.5 hover:border-[var(--brand-500)] focus-visible:border-[var(--brand-500)]",
+                disabled && "cursor-not-allowed opacity-40",
+                isSelected && "border-2 border-[var(--brand-500)]"
+              )}
+            >
+              <img src={uc.icon} alt="" className="mb-2 h-12 w-12" />
+              <span>{uc.title}</span>
+              {isSelected && (
+                <span className="absolute right-2 top-2 flex h-6 w-6 items-center justify-center rounded-full bg-[var(--brand-500)] text-white">
+                  {index + 1}
+                </span>
+              )}
+            </button>
+          );
+        })}
+      </div>
+      <div className="mt-4 flex flex-wrap gap-3">
+        <button
+          type="button"
+          onClick={handleAuto}
+          className="rounded-full border px-3 py-1 text-sm"
+        >
+          {autoPick ? "Выбрать вручную" : "Не знаю — выбрать за меня"}
+        </button>
+        {USE_CASES.some((c) => !c.popular) && (
+          <button
+            type="button"
+            onClick={() => setShowMore((s) => !s)}
+            className="rounded-full border px-3 py-1 text-sm"
+          >
+            {showMore ? "Скрыть сценарии" : "Показать больше сценариев"}
+          </button>
+        )}
+      </div>
+      {selected.map((u) => {
+        const conf = USE_CASES.find((c) => c.id === u.id);
+        if (!conf?.subprops) return null;
+        return (
+          <div key={u.id} className="mt-4 space-y-2">
+            {conf.subprops.map((sp) => (
+              <div key={sp.key} className="flex items-center gap-2">
+                <label className="w-40 text-sm" htmlFor={`${u.id}-${sp.key}`}>
+                  {SUBPROP_LABELS[sp.key]}
+                </label>
+                <select
+                  id={`${u.id}-${sp.key}`}
+                  className="input flex-1"
+                  value={u.props?.[sp.key] ?? ""}
+                  onChange={(e) => updateProp(u.id, sp.key, e.target.value)}
+                >
+                  <option value="">—</option>
+                  {sp.options.map((opt) => (
+                    <option key={opt} value={opt}>
+                      {OPTION_LABELS[sp.key][opt]}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            ))}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function sendEvent(event: string, props?: Record<string, unknown>) {
+  if (typeof window !== "undefined") {
+    const win = window as {
+      plausible?: (e: string, o?: Record<string, unknown>) => void;
+    };
+    win.plausible?.(event, props);
+  }
+}

--- a/src/components/quiz/usecases.config.ts
+++ b/src/components/quiz/usecases.config.ts
@@ -1,0 +1,78 @@
+import type { UseCase } from "@/types/usecases";
+
+export const USE_CASES: UseCase[] = [
+  {
+    id: 'office',
+    title: 'Офис',
+    icon: '/icons/usecases/placeholder.svg',
+    popular: true,
+    subprops: [
+      { key: 'dress_code', type: 'enum', options: ['business_formal', 'smart_casual', 'free'] },
+    ],
+  },
+  {
+    id: 'everyday',
+    title: 'Каждый день',
+    icon: '/icons/usecases/placeholder.svg',
+    popular: true,
+    subprops: [
+      { key: 'formality', type: 'enum', options: ['relaxed', 'smart_casual'] },
+    ],
+  },
+  {
+    id: 'date',
+    title: 'Свидание/вечер',
+    icon: '/icons/usecases/placeholder.svg',
+    popular: true,
+    subprops: [
+      { key: 'place', type: 'enum', options: ['restaurant', 'walk', 'cinema'] },
+    ],
+  },
+  {
+    id: 'weekend',
+    title: 'Выходные/кэжуал',
+    icon: '/icons/usecases/placeholder.svg',
+    popular: true,
+    subprops: [
+      { key: 'formality', type: 'enum', options: ['relaxed', 'smart_casual'] },
+    ],
+  },
+  {
+    id: 'travel',
+    title: 'Путешествие',
+    icon: '/icons/usecases/placeholder.svg',
+    popular: true,
+    subprops: [
+      { key: 'climate', type: 'enum', options: ['hot', 'mild', 'cold'] },
+      { key: 'trip_duration', type: 'enum', options: ['2-3d', '1w', '2w+'] },
+    ],
+  },
+  {
+    id: 'season',
+    title: 'Сезонная капсула',
+    icon: '/icons/usecases/placeholder.svg',
+    popular: true,
+    subprops: [
+      { key: 'season', type: 'enum', options: ['ss', 'aw'] },
+    ],
+  },
+  {
+    id: 'event',
+    title: 'Событие',
+    icon: '/icons/usecases/placeholder.svg',
+    popular: true,
+    subprops: [
+      { key: 'event_type', type: 'enum', options: ['wedding', 'grad', 'cocktail', 'corporate', 'other'] },
+    ],
+  },
+  { id: 'business_trip', title: 'Бизнес-поездка', icon: '/icons/usecases/placeholder.svg' },
+  { id: 'wedding_guest', title: 'Свадьба', icon: '/icons/usecases/placeholder.svg' },
+  { id: 'party', title: 'Вечеринка/коктейль', icon: '/icons/usecases/placeholder.svg' },
+  { id: 'campus', title: 'Университет/кампус', icon: '/icons/usecases/placeholder.svg' },
+  { id: 'athleisure', title: 'Спорт-шик', icon: '/icons/usecases/placeholder.svg' },
+  { id: 'wardrobe_refresh', title: 'Обновление базы', icon: '/icons/usecases/placeholder.svg' },
+  { id: 'photo_shoot', title: 'Фотосессия', icon: '/icons/usecases/placeholder.svg' },
+  { id: 'streetwear', title: 'Уличный стиль', icon: '/icons/usecases/placeholder.svg' },
+  { id: 'vacation_beach', title: 'Отпуск-море', icon: '/icons/usecases/placeholder.svg' },
+  { id: 'outdoor', title: 'Outdoor/погода', icon: '/icons/usecases/placeholder.svg' },
+];

--- a/src/types/usecases.ts
+++ b/src/types/usecases.ts
@@ -1,0 +1,41 @@
+export type UseCaseId =
+  | 'office'
+  | 'everyday'
+  | 'date'
+  | 'weekend'
+  | 'travel'
+  | 'season'
+  | 'event'
+  | 'business_trip'
+  | 'wedding_guest'
+  | 'party'
+  | 'campus'
+  | 'athleisure'
+  | 'wardrobe_refresh'
+  | 'photo_shoot'
+  | 'streetwear'
+  | 'vacation_beach'
+  | 'outdoor';
+
+export type UseCaseSubprop =
+  | { key: 'dress_code'; type: 'enum'; options: ('business_formal' | 'smart_casual' | 'free')[] }
+  | { key: 'climate'; type: 'enum'; options: ('hot' | 'mild' | 'cold')[] }
+  | { key: 'trip_duration'; type: 'enum'; options: ('2-3d' | '1w' | '2w+')[] }
+  | { key: 'season'; type: 'enum'; options: ('ss' | 'aw' | 'spring' | 'summer' | 'autumn' | 'winter')[] }
+  | { key: 'event_type'; type: 'enum'; options: ('wedding' | 'grad' | 'cocktail' | 'corporate' | 'other')[] }
+  | { key: 'formality'; type: 'enum'; options: ('relaxed' | 'smart_casual')[] }
+  | { key: 'place'; type: 'enum'; options: ('restaurant' | 'walk' | 'cinema')[] };
+
+export interface UseCase {
+  id: UseCaseId;
+  title: string;
+  icon: string;
+  popular?: boolean;
+  subprops?: UseCaseSubprop[];
+}
+
+export interface SelectedUseCase {
+  id: UseCaseId;
+  priority: 1 | 2 | 3;
+  props?: Record<string, string>;
+}


### PR DESCRIPTION
## Summary
- add reusable use case config and selection step
- wire use case step into quiz flow and analytics
- support priority reordering, sub-parameters and auto-pick toggle

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68acfae633cc832c97cf8c560d13de10