### PR TITLE
feat: revamp measurements quiz step

### DIFF
--- a/src/components/Quiz.tsx
+++ b/src/components/Quiz.tsx
@@ -5,6 +5,7 @@ import StyleStep from "./quiz/StyleStep";
 import ColorDislikeStep from "./quiz/ColorDislikeStep";
 import PhotoStep from "./quiz/PhotoStep";
 import FavoriteBrandsStep, { type Brand } from "./quiz/FavoriteBrandsStep";
+import MeasurementsStep from "./quiz/MeasurementsStep";
 
 interface QuizProps {
   onClose: () => void;
@@ -20,12 +21,18 @@ interface QuizData {
   height_cm?: number;
   weight_kg?: number;
   age_band?: string;
-  top_size?: string;
-  bottom_waist?: number;
-  bottom_length?: number;
+  sizes_unit: "metric" | "imperial";
+  top_size_ru?: number;
+  bottom_size_ru?: number;
+  jeans_waist_in?: number;
+  jeans_inseam_cm?: number;
+  bust_cm?: number;
+  waist_cm?: number;
+  hips_cm?: number;
+  top_fit?: "tight" | "regular" | "relaxed" | "oversized";
+  pants_cut?: "straight" | "slim" | "wide" | "flare";
+  sizes_autopick: boolean;
   shoe_ru?: number;
-  fit_pref_top?: string;
-  fit_pref_bottom?: string;
   style: string[];
   color_dislike: string[];
   favorite_brands: Brand[];
@@ -67,12 +74,18 @@ export function Quiz({ onClose }: QuizProps) {
     height_cm: 180,
     weight_kg: 75,
     age_band: "25_34",
-    top_size: "48",
-    bottom_waist: 82,
-    bottom_length: 100,
+    sizes_unit: "metric",
+    top_size_ru: 48,
+    bottom_size_ru: 48,
+    jeans_waist_in: 30,
+    jeans_inseam_cm: 76,
+    bust_cm: 96,
+    waist_cm: 82,
+    hips_cm: 100,
+    top_fit: "regular",
+    pants_cut: "straight",
+    sizes_autopick: false,
     shoe_ru: 42,
-    fit_pref_top: "regular",
-    fit_pref_bottom: "straight",
     style: [],
     color_dislike: [],
     favorite_brands: [],
@@ -225,79 +238,7 @@ export function Quiz({ onClose }: QuizProps) {
         );
       case "measurements":
         return (
-          <div>
-            <h2 className="mb-2 text-xl font-semibold">Размеры</h2>
-            <p className="mb-4 text-sm text-gray-600">
-              Не уверены в параметрах? Нажмите «Не знаю», и наши ИИ‑алгоритмы подберут их автоматически.
-            </p>
-            <div className="space-y-4">
-              <select
-                className="input w-full"
-                value={data.top_size ?? ""}
-                onChange={(e) => update({ top_size: e.target.value })}
-              >
-                <option value="">Размер верха (RU)</option>
-                {Array.from({ length: 9 }, (_, i) => 44 + i * 2).map((v) => (
-                  <option key={v} value={String(v)}>
-                    {v}
-                  </option>
-                ))}
-                <option value="dont_know">Не знаю</option>
-              </select>
-              <input
-                type="number"
-                className="input w-full"
-                value={data.bottom_waist ?? ""}
-                onChange={(e) => update({ bottom_waist: Number(e.target.value) })}
-                placeholder="Талия"
-              />
-              <input
-                type="number"
-                className="input w-full"
-                value={data.bottom_length ?? ""}
-                onChange={(e) => update({ bottom_length: Number(e.target.value) })}
-                placeholder="Длина низа"
-              />
-              <select
-                className="input w-full"
-                value={data.fit_pref_top ?? ""}
-                onChange={(e) => update({ fit_pref_top: e.target.value })}
-              >
-                <option value="">Посадка верха</option>
-                <option value="slim">Slim</option>
-                <option value="regular">Regular</option>
-                <option value="relaxed">Relaxed</option>
-                <option value="any">Любая</option>
-              </select>
-              <select
-                className="input w-full"
-                value={data.fit_pref_bottom ?? ""}
-                onChange={(e) => update({ fit_pref_bottom: e.target.value })}
-              >
-                <option value="">Посадка низа</option>
-                <option value="tapered">Tapered</option>
-                <option value="straight">Straight</option>
-                <option value="relaxed">Relaxed</option>
-                <option value="any">Любая</option>
-              </select>
-            </div>
-            <button
-              type="button"
-              className="mt-4 text-sm text-gray-600 underline"
-              onClick={() => {
-                update({
-                  top_size: "dont_know",
-                  bottom_waist: undefined,
-                  bottom_length: undefined,
-                  fit_pref_top: undefined,
-                  fit_pref_bottom: undefined,
-                });
-                next();
-              }}
-            >
-              Не знаю
-            </button>
-          </div>
+          <MeasurementsStep data={data} onChange={update} />
         );
       case "shoe_ru":
         return (

--- a/src/components/quiz/MeasurementsStep.tsx
+++ b/src/components/quiz/MeasurementsStep.tsx
@@ -1,0 +1,287 @@
+"use client";
+
+import { useState } from "react";
+import clsx from "clsx";
+
+export interface MeasurementsData {
+  sizes_unit: "metric" | "imperial";
+  top_size_ru?: number;
+  bottom_size_ru?: number;
+  jeans_waist_in?: number;
+  jeans_inseam_cm?: number;
+  bust_cm?: number;
+  waist_cm?: number;
+  hips_cm?: number;
+  top_fit?: "tight" | "regular" | "relaxed" | "oversized";
+  pants_cut?: "straight" | "slim" | "wide" | "flare";
+  sizes_autopick: boolean;
+}
+
+interface MeasurementsStepProps {
+  data: MeasurementsData;
+  onChange: (data: Partial<MeasurementsData>) => void;
+}
+
+export default function MeasurementsStep({ data, onChange }: MeasurementsStepProps) {
+  const { sizes_unit: unit, sizes_autopick } = data;
+  const [guideOpen, setGuideOpen] = useState(false);
+
+  const toDisplay = (cm?: number) => {
+    if (cm == null) return "";
+    return unit === "metric" ? String(Math.round(cm)) : String(Math.round(cm / 2.54));
+  };
+
+  const handleMeasure = (field: keyof MeasurementsData, value: string) => {
+    if (!value) {
+      onChange({ [field]: undefined });
+      return;
+    }
+    let num = Number(value);
+    if (field.endsWith("_cm") || field === "jeans_inseam_cm") {
+      if (unit === "imperial") num = Math.round(num * 2.54);
+      onChange({ [field]: num });
+      return;
+    }
+    onChange({ [field]: num });
+  };
+
+  const handleUnit = (u: "metric" | "imperial") => {
+    if (u !== unit) onChange({ sizes_unit: u });
+  };
+
+  const toggleAuto = () => {
+    onChange({ sizes_autopick: !sizes_autopick });
+  };
+
+  return (
+    <div>
+      <h2 className="mb-2 text-xl font-semibold">Размеры</h2>
+      <p className="mb-4 text-sm text-gray-600">
+        Не уверены в параметрах? Нажмите «Не знаю», и наши алгоритмы подберут их автоматически.
+      </p>
+
+      <div className="mb-4">
+        <div className="inline-flex overflow-hidden rounded border">
+          <button
+            type="button"
+            className={clsx(
+              "px-3 py-1 text-sm",
+              unit === "metric"
+                ? "bg-[var(--brand-500)] text-white"
+                : "bg-white text-gray-700"
+            )}
+            onClick={() => handleUnit("metric")}
+          >
+            см
+          </button>
+          <button
+            type="button"
+            className={clsx(
+              "px-3 py-1 text-sm",
+              unit === "imperial"
+                ? "bg-[var(--brand-500)] text-white"
+                : "bg-white text-gray-700"
+            )}
+            onClick={() => handleUnit("imperial")}
+          >
+            inch
+          </button>
+        </div>
+      </div>
+
+      <div className={clsx("grid gap-4", "sm:grid-cols-2")}
+        aria-disabled={sizes_autopick}
+      >
+        <div className={clsx(sizes_autopick && "opacity-60")}
+        >
+          <label className="mb-1 block text-sm">Верх (RU)</label>
+          <select
+            className="input w-full"
+            value={data.top_size_ru ?? ""}
+            onChange={(e) => handleMeasure("top_size_ru", e.target.value)}
+            disabled={sizes_autopick}
+          >
+            <option value="">Выберите размер</option>
+            {Array.from({ length: 10 }, (_, i) => 38 + i * 2).map((v) => (
+              <option key={v} value={v}>
+                {v}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className={clsx(sizes_autopick && "opacity-60")}
+        >
+          <label className="mb-1 block text-sm">Низ (RU)</label>
+          <select
+            className="input w-full"
+            value={data.bottom_size_ru ?? ""}
+            onChange={(e) => handleMeasure("bottom_size_ru", e.target.value)}
+            disabled={sizes_autopick}
+          >
+            <option value="">Выберите размер</option>
+            {Array.from({ length: 10 }, (_, i) => 38 + i * 2).map((v) => (
+              <option key={v} value={v}>
+                {v}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className={clsx("sm:col-span-2", sizes_autopick && "opacity-60")}
+        >
+          <label className="mb-1 block text-sm">Джинсы</label>
+          <div className="flex gap-2">
+            <input
+              type="number"
+              className="input w-24"
+              placeholder="W"
+              value={data.jeans_waist_in ?? ""}
+              onChange={(e) => handleMeasure("jeans_waist_in", e.target.value)}
+              disabled={sizes_autopick}
+            />
+            <input
+              type="number"
+              className="input w-24"
+              placeholder={`L (${unit === "metric" ? "см" : "inch"})`}
+              value={toDisplay(data.jeans_inseam_cm)}
+              onChange={(e) => handleMeasure("jeans_inseam_cm", e.target.value)}
+              disabled={sizes_autopick}
+            />
+          </div>
+        </div>
+        <div className={clsx("sm:col-span-2", sizes_autopick && "opacity-60")}
+        >
+          <label className="mb-1 block text-sm">
+            Грудь / Талия / Бёдра ({unit === "metric" ? "см" : "inch"})
+          </label>
+          <div className="flex gap-2">
+            <input
+              type="number"
+              className="input flex-1"
+              placeholder="Грудь"
+              value={toDisplay(data.bust_cm)}
+              onChange={(e) => handleMeasure("bust_cm", e.target.value)}
+              disabled={sizes_autopick}
+            />
+            <input
+              type="number"
+              className="input flex-1"
+              placeholder="Талия"
+              value={toDisplay(data.waist_cm)}
+              onChange={(e) => handleMeasure("waist_cm", e.target.value)}
+              disabled={sizes_autopick}
+            />
+            <input
+              type="number"
+              className="input flex-1"
+              placeholder="Бёдра"
+              value={toDisplay(data.hips_cm)}
+              onChange={(e) => handleMeasure("hips_cm", e.target.value)}
+              disabled={sizes_autopick}
+            />
+          </div>
+        </div>
+        <div className={clsx(sizes_autopick && "opacity-60")}
+        >
+          <label className="mb-1 block text-sm">Посадка верха</label>
+          <div className="flex flex-wrap gap-2">
+            {["tight", "regular", "relaxed", "oversized"].map((f) => (
+              <button
+                key={f}
+                type="button"
+                onClick={() => onChange({ top_fit: data.top_fit === f ? undefined : (f as any) })}
+                className={clsx(
+                  "rounded-full border px-3 py-1 text-sm",
+                  data.top_fit === f
+                    ? "border-[var(--brand-500)] bg-[var(--brand-50)] text-[var(--brand-700)]"
+                    : "border-gray-300 text-gray-600"
+                )}
+                disabled={sizes_autopick}
+              >
+                {f === "tight"
+                  ? "Облегающий"
+                  : f === "regular"
+                  ? "Regular"
+                  : f === "relaxed"
+                  ? "Свободный"
+                  : "Oversized"}
+              </button>
+            ))}
+          </div>
+        </div>
+        <div className={clsx(sizes_autopick && "opacity-60")}
+        >
+          <label className="mb-1 block text-sm">Крой брюк</label>
+          <div className="flex flex-wrap gap-2">
+            {["straight", "slim", "wide", "flare"].map((f) => (
+              <button
+                key={f}
+                type="button"
+                onClick={() => onChange({ pants_cut: data.pants_cut === f ? undefined : (f as any) })}
+                className={clsx(
+                  "rounded-full border px-3 py-1 text-sm",
+                  data.pants_cut === f
+                    ? "border-[var(--brand-500)] bg-[var(--brand-50)] text-[var(--brand-700)]"
+                    : "border-gray-300 text-gray-600"
+                )}
+                disabled={sizes_autopick}
+              >
+                {f === "straight"
+                  ? "Straight"
+                  : f === "slim"
+                  ? "Slim"
+                  : f === "wide"
+                  ? "Wide/Loose"
+                  : "Flare"}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-4 flex flex-wrap items-center gap-4">
+        <button
+          type="button"
+          className="text-sm text-gray-600 underline"
+          onClick={() => setGuideOpen(true)}
+        >
+          Как снять мерки
+        </button>
+        <button
+          type="button"
+          onClick={toggleAuto}
+          className={clsx(
+            "rounded-full border px-3 py-1 text-sm",
+            sizes_autopick
+              ? "border-[var(--brand-500)] bg-[var(--brand-50)] text-[var(--brand-700)]"
+              : "border-gray-300 text-gray-600"
+          )}
+        >
+          Не знаю — подобрать автоматически
+        </button>
+      </div>
+
+      {guideOpen && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+          <div className="max-w-sm rounded-lg bg-white p-6 text-sm">
+            <h3 className="mb-2 text-lg font-semibold">Как снять мерки</h3>
+            <p className="mb-2">
+              Грудь: сантиметр горизонтально по самым выступающим точкам.
+            </p>
+            <p className="mb-2">Талия: самая узкая часть, не втягивайте живот.</p>
+            <p className="mb-4">
+              Бёдра: по самым выступающим точкам ягодиц. Сантиметр не натягивайте.
+            </p>
+            <button
+              type="button"
+              className="button primary w-full"
+              onClick={() => setGuideOpen(false)}
+            >
+              Понятно
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add MeasurementsStep component with unit toggle, size inputs and autopick option
- wire new size profile fields into Quiz component

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68acfb40faa0832c8ab8bbc32489e58c